### PR TITLE
Skip empty report entries

### DIFF
--- a/src/ims/store/sqlite/_store.py
+++ b/src/ims/store/sqlite/_store.py
@@ -545,7 +545,7 @@ class DataStore(IMSDataStore):
             )
             for row in cursor.execute(
                 self._query_incident_reportEntries, params
-            )
+            ) if row["TEXT"]
         )
 
         # FIXME: This is because schema thinks concentric is an int


### PR DESCRIPTION
Skip empty report entries, as they aren't allowed any more, but apparently exist in small numbers in some old DBs.  We'll just pretend they don't exist.