### PR TITLE
Schema update

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include .coveragerc
+include .dockerignore
 include bin/.common.sh
 include bin/build
 include bin/deploy

--- a/src/ims/store/_abc.py
+++ b/src/ims/store/_abc.py
@@ -47,9 +47,6 @@ class IMSDataStore(ABC):
     async def upgradeSchema(self) -> None:
         """
         Upgrade the data store schema to the current version.
-
-        Return `True` if an upgrade was executed, `False` if no upgrade was
-        necessary.
         """
 
     @abstractmethod

--- a/src/ims/store/_db.py
+++ b/src/ims/store/_db.py
@@ -1809,7 +1809,7 @@ class DatabaseManager(object):
 
     store: DatabaseStore
 
-    async def upgradeSchema(self, targetVersion: Optional[int] = None) -> None:
+    async def upgradeSchema(self, targetVersion: Optional[int] = None) -> bool:
         """
         Apply schema updates
         """
@@ -1831,6 +1831,7 @@ class DatabaseManager(object):
                 "No upgrade required for schema version {version}",
                 version=currentVersion,
             )
+            return False
 
         if currentVersion > latestVersion:
             raise StorageError(
@@ -1883,3 +1884,5 @@ class DatabaseManager(object):
                     f"({fromVersion} <= {currentVersion})"
                 )
             currentVersion = fromVersion
+
+        return True

--- a/src/ims/store/_db.py
+++ b/src/ims/store/_db.py
@@ -307,7 +307,7 @@ class DatabaseStore(IMSDataStore):
         Apply the given schema to the database.
         """
 
-    async def upgradeSchema(self, targetVersion: Optional[int] = None) -> bool:
+    async def upgradeSchema(self, targetVersion: Optional[int] = None) -> None:
         """
         See :meth:`IMSDataStore.upgradeSchema`.
         """
@@ -1809,7 +1809,7 @@ class DatabaseManager(object):
 
     store: DatabaseStore
 
-    async def upgradeSchema(self, targetVersion: Optional[int] = None) -> bool:
+    async def upgradeSchema(self, targetVersion: Optional[int] = None) -> None:
         """
         Apply schema updates
         """
@@ -1828,10 +1828,9 @@ class DatabaseManager(object):
         if currentVersion == latestVersion:
             # No upgrade needed
             self._log.debug(
-                "No upgrade required to schema version {version}",
-                version=version,
+                "No upgrade required for schema version {version}",
+                version=currentVersion,
             )
-            return False
 
         if currentVersion > latestVersion:
             raise StorageError(
@@ -1884,5 +1883,3 @@ class DatabaseManager(object):
                     f"({fromVersion} <= {currentVersion})"
                 )
             currentVersion = fromVersion
-
-        return True

--- a/src/ims/store/_db.py
+++ b/src/ims/store/_db.py
@@ -1842,7 +1842,18 @@ class DatabaseManager(object):
             else:
                 fileID = f"{toVersion}-from-{fromVersion}"
 
-            sql = self.store.loadSchema(version=fileID)
+            try:
+                sql = self.store.loadSchema(version=fileID)
+            except FileNotFoundError:
+                self._log.critical(
+                    "Unable to upgrade schema in store {store.__class__} "
+                    "from {fromVersion} to {toVersion} "
+                    "due to missing schema file",
+                    store=self.store,
+                    fromVersion=fromVersion,
+                    toVersion=toVersion,
+                )
+                raise StorageError("Unable to upgrade schema")
             await self.store.applySchema(sql)
 
         fromVersion = version

--- a/src/ims/store/mysql/schema/5-from-4.mysql
+++ b/src/ims/store/mysql/schema/5-from-4.mysql
@@ -1,11 +1,11 @@
--- Increase column sizes
+/* Increase column sizes */
 
 alter table EVENT modify NAME varchar(128) not null;
 
 alter table CONCENTRIC_STREET modify NAME varchar(128) not null;
 
-alter table INCIDENT modify LOCATION_NAME varchar(1024) not null;
+alter table INCIDENT modify LOCATION_NAME varchar(1024);
 
--- Update schema version
+/* Update schema version */
 
 update SCHEMA_INFO set VERSION = 5;

--- a/src/ims/store/mysql/schema/5-from-4.mysql
+++ b/src/ims/store/mysql/schema/5-from-4.mysql
@@ -1,0 +1,11 @@
+-- Increase column sizes
+
+alter table EVENT modify NAME varchar(128) not null;
+
+alter table CONCENTRIC_STREET modify NAME varchar(128) not null;
+
+alter table INCIDENT modify LOCATION_NAME varchar(1024) not null;
+
+-- Update schema version
+
+update SCHEMA_INFO set VERSION = 5;

--- a/src/ims/store/mysql/test/base.py
+++ b/src/ims/store/mysql/test/base.py
@@ -39,6 +39,7 @@ class TestDataStore(DataStore, TestDatabaseStoreMixIn):
     See :class:`SuperTestDataStore`.
     """
 
+    firstSchemaVersion: ClassVar[int] = 4
     maxIncidentNumber: ClassVar[int] = 4294967295
     exceptionClass: ClassVar[type] = MySQLError
 

--- a/src/ims/store/mysql/test/test_store_core.py
+++ b/src/ims/store/mysql/test/test_store_core.py
@@ -211,7 +211,9 @@ class DataStoreCoreTests(AsynchronousTestCase):
         :meth:`DataStore._dbSchemaVersion` returns the schema version for the
         given database.
         """
-        for version in range(2, DataStore.schemaVersion + 1):
+        for version in range(
+            TestDataStore.firstSchemaVersion, DataStore.schemaVersion + 1
+        ):
             with patch("ims.store.mysql.DataStore.schemaVersion", version):
                 store = await self.store()
 
@@ -219,7 +221,7 @@ class DataStoreCoreTests(AsynchronousTestCase):
                 currentVersion = await store.dbSchemaVersion()
                 assert currentVersion == 0
 
-                # Upgrade and confirm we're not at the desired version
+                # Upgrade and confirm we're at the desired version
                 await store.upgradeSchema()
                 currentVersion = await store.dbSchemaVersion()
                 self.assertEqual(currentVersion, version)

--- a/src/ims/store/mysql/test/test_store_core.py
+++ b/src/ims/store/mysql/test/test_store_core.py
@@ -31,7 +31,7 @@ from ims.ext.trial import AsynchronousTestCase, asyncAsDeferred
 
 from .base import TestDataStore
 from .service import MySQLService, randomDatabaseName
-from .._store import DataStore
+from .._store import DataStore, ReconnectingConnectionPool
 
 
 __all__ = ()
@@ -223,3 +223,12 @@ class DataStoreCoreTests(AsynchronousTestCase):
                 await store.upgradeSchema()
                 currentVersion = await store.dbSchemaVersion()
                 self.assertEqual(currentVersion, version)
+
+    @asyncAsDeferred
+    async def test_db(self) -> None:
+        """
+        :meth:`DataStore._db` returns a :class:`ReconnectingConnectionPool`.
+        """
+        store = await self.store()
+
+        self.assertIsInstance(store._db, ReconnectingConnectionPool)

--- a/src/ims/store/sqlite/schema/2-from-1.sqlite
+++ b/src/ims/store/sqlite/schema/2-from-1.sqlite
@@ -75,4 +75,4 @@ alter table INCIDENT_INCIDENT_REPORT rename to INCIDENT__INCIDENT_REPORT;
 
 -- Update schema version
 
-update SCHEMA_INFO set version = 2;
+update SCHEMA_INFO set VERSION = 2;

--- a/src/ims/store/sqlite/schema/3-from-2.sqlite
+++ b/src/ims/store/sqlite/schema/3-from-2.sqlite
@@ -58,4 +58,4 @@ pragma foreign_keys = true;
 
 -- Update schema version
 
-update SCHEMA_INFO set version = 3;
+update SCHEMA_INFO set VERSION = 3;

--- a/src/ims/store/sqlite/schema/4-from-3.sqlite
+++ b/src/ims/store/sqlite/schema/4-from-3.sqlite
@@ -112,4 +112,4 @@ insert into ACCESS_MODE (ID) values ('report');
 
 -- Update schema version
 
-update SCHEMA_INFO set version = 4;
+update SCHEMA_INFO set VERSION = 4;

--- a/src/ims/store/sqlite/test/base.py
+++ b/src/ims/store/sqlite/test/base.py
@@ -37,6 +37,7 @@ class TestDataStore(DataStore, TestDatabaseStoreMixIn):
     See :class:`SuperTestDataStore`.
     """
 
+    firstSchemaVersion: ClassVar[int] = 1
     maxIncidentNumber: ClassVar[int] = SQLITE_MAX_INT
     exceptionClass: ClassVar[type] = SQLiteError
 

--- a/src/ims/store/sqlite/test/test_store_core.py
+++ b/src/ims/store/sqlite/test/test_store_core.py
@@ -341,7 +341,7 @@ class DataStoreCoreTests(AsynchronousTestCase):
         self.assertEqual(
             f.getErrorMessage(),
             f"Schema version {version} is too new "
-            f"(current version is {store.schemaVersion})",
+            f"(latest version is {store.schemaVersion})",
         )
 
     def test_validate_super(self) -> None:

--- a/src/ims/store/sqlite/test/test_store_core.py
+++ b/src/ims/store/sqlite/test/test_store_core.py
@@ -246,9 +246,7 @@ class DataStoreCoreTests(AsynchronousTestCase):
         with createDB(None, DataStore.loadSchema(version=latestVersion)) as db:
             currentSchemaInfo = getSchemaInfo(db)
 
-        for version in range(
-            TestDataStore.firstSchemaVersion, latestVersion
-        ):
+        for version in range(TestDataStore.firstSchemaVersion, latestVersion):
             path = Path(self.mktemp())
             createDB(path, DataStore.loadSchema(version=version))
 

--- a/src/ims/store/sqlite/test/test_store_core.py
+++ b/src/ims/store/sqlite/test/test_store_core.py
@@ -246,7 +246,9 @@ class DataStoreCoreTests(AsynchronousTestCase):
         with createDB(None, DataStore.loadSchema(version=latestVersion)) as db:
             currentSchemaInfo = getSchemaInfo(db)
 
-        for version in range(TestDataStore.firstSchemaVersion, latestVersion):
+        for version in range(
+            TestDataStore.firstSchemaVersion, latestVersion
+        ):
             path = Path(self.mktemp())
             createDB(path, DataStore.loadSchema(version=version))
 

--- a/src/ims/store/sqlite/test/test_store_core.py
+++ b/src/ims/store/sqlite/test/test_store_core.py
@@ -196,7 +196,9 @@ class DataStoreCoreTests(AsynchronousTestCase):
         :meth:`DataStore._dbSchemaVersion` returns the schema version for the
         given database.
         """
-        for version in range(1, DataStore.schemaVersion + 1):
+        for version in range(
+            TestDataStore.firstSchemaVersion, DataStore.schemaVersion + 1
+        ):
             db = createDB(None, DataStore.loadSchema(version=version))
 
             self.assertEqual(DataStore._dbSchemaVersion(db), version)
@@ -239,19 +241,21 @@ class DataStoreCoreTests(AsynchronousTestCase):
             printSchema(db, out)
             return out.getvalue()
 
-        currentVersion = DataStore.schemaVersion
+        latestVersion = DataStore.schemaVersion
 
-        with createDB(None, DataStore.loadSchema(version=currentVersion)) as db:
+        with createDB(None, DataStore.loadSchema(version=latestVersion)) as db:
             currentSchemaInfo = getSchemaInfo(db)
 
-        for version in range(1, currentVersion):
+        for version in range(
+            TestDataStore.firstSchemaVersion, latestVersion
+        ):
             path = Path(self.mktemp())
             createDB(path, DataStore.loadSchema(version=version))
 
             store = DataStore(dbPath=path)
             self.successResultOf(store.upgradeSchema())
 
-            self.assertEqual(store._dbSchemaVersion(store._db), currentVersion)
+            self.assertEqual(store._dbSchemaVersion(store._db), latestVersion)
 
             schemaInfo = getSchemaInfo(store._db)
 

--- a/tox.ini
+++ b/tox.ini
@@ -77,6 +77,9 @@ skip_install = True
 deps =
     black==19.10b0
 
+setenv =
+    BLACK_LINT_ARGS=--check
+
 commands =
     black {env:BLACK_LINT_ARGS:} src
 


### PR DESCRIPTION
This adds schema version 5, which increases the size of some columns.

We haven't had to do any schema upgrades with MySQL before, so this also adds tests and related cleanup.