### PR TITLE
Make Trivy and Safety optional

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -122,6 +122,7 @@ jobs:
 
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    continue-on-error: true
 
     steps:
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -387,6 +387,7 @@ jobs:
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    continue-on-error: true
 
     steps:
 
@@ -447,7 +448,7 @@ jobs:
           NOTIFY_SMTP_PASSWORD: ${{ secrets.NOTIFY_SMTP_PASSWORD }}
           NOTIFY_EMAIL_RECIPIENT: ${{ secrets.NOTIFY_EMAIL_RECIPIENT }}
           NOTIFY_EMAIL_SENDER: ${{ secrets.NOTIFY_EMAIL_SENDER }}
-          CI: true
+          CI: "true"
           PROJECT_NAME: Ranger IMS Server
           REPOSITORY_ID: ${{ github.repository }}
           BUILD_NUMBER: 0


### PR DESCRIPTION
Make Trivy and Safety optional because we need to be able to fix other things