### PR TITLE
Bump PyYAML

### DIFF
--- a/requirements/requirements-direct.txt
+++ b/requirements/requirements-direct.txt
@@ -8,7 +8,7 @@ jwcrypto==1.5.0
 klein==21.8.0
 PyMySQL==1.1.0
 pyOpenSSL==23.2.0
-PyYAML==6.0
+PyYAML==6.0.1
 service-identity==21.1.0
 Twisted==22.10.0
 Werkzeug==2.2.3


### PR DESCRIPTION
PyYML 6.0 is causing CI errors; bump to 6.0.1.