### PR TITLE
feat: help user not lose unsaved changes

### DIFF
--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -30,6 +30,14 @@ function initIncidentPage() {
         // Scroll to incident_report_add field
         $("html, body").animate({ scrollTop: $("#incident_report_add").offset().top }, 500);
         $("#incident_report_add").focus();
+
+        // Warn the user if they're about to navigate away with unsaved text.
+        window.addEventListener('beforeunload', function (e) {
+            if (document.getElementById("incident_report_add").value !== '') {
+                e.preventDefault();
+                e.returnValue = '';
+            }
+        });
     }
 
     function loadedBody() {


### PR DESCRIPTION
As things were, it was easy to accidentally navigate away from the incident page and lose your unsaved text. I know this would've saved me a lot of pain at Burning Man 2023, and I'm sure other people have been bitten by this problem too.

I'm a JavaScript noob, so please feel free to suggest any changes.