### PR TITLE
fix: do case insensitive sort of Ranger handles

### DIFF
--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -515,7 +515,7 @@ function drawRangers() {
     if (handles == undefined) {
         handles = [];
     } else {
-        handles.sort();
+        handles.sort((a, b) => a.localeCompare(b));
     }
 
     for (var i in handles) {
@@ -545,7 +545,7 @@ function drawRangersToAdd() {
     for (var handle in personnel) {
         handles.push(handle);
     }
-    handles.sort();
+    handles.sort((a, b) => a.localeCompare(b));
 
     select.empty();
     select.append($("<option />"));


### PR DESCRIPTION
Previously the list of Rangers in the "Add" dropdowns used case-sensitive sorting, so all the handles starting with a lowercase character were listed at the very end. This was rather unintuitive. localeCompare seems to be the preferred way to do this, and it uses the host's locale by default.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare


Before and after pics below
![image](https://github.com/burningmantech/ranger-ims-server/assets/23407555/763bd477-5900-44a0-83d0-9f3c83e04a48)
![image](https://github.com/burningmantech/ranger-ims-server/assets/23407555/b9f51716-0f9f-40c9-b0a8-02958cb5dbc5)
