### PR TITLE
[BUGFIX] Switch jquery to alternate https source 1164

### DIFF
--- a/src/ims/application/_external.py
+++ b/src/ims/application/_external.py
@@ -698,11 +698,13 @@ class ExternalApplication:
     )
 
     jqueryJSSourceURL = URL.fromText(
-        f"https://cdnjs.cloudflare.com/ajax/libs/jquery/{jqueryVersionNumber}/jquery.min.js"
+        f"https://cdnjs.cloudflare.com/ajax/libs/jquery/"
+        f"{jqueryVersionNumber}/jquery.min.js"
     )
 
     jqueryMapSourceURL = URL.fromText(
-        f"https://cdnjs.cloudflare.com/ajax/libs/jquery/{jqueryVersionNumber}/jquery.min.map"
+        f"https://cdnjs.cloudflare.com/ajax/libs/jquery/"
+        f"{jqueryVersionNumber}/jquery.min.map"
     )
 
     dataTablesSourceURL = URL.fromText(

--- a/src/ims/application/_external.py
+++ b/src/ims/application/_external.py
@@ -698,11 +698,11 @@ class ExternalApplication:
     )
 
     jqueryJSSourceURL = URL.fromText(
-        f"http://code.jquery.com/{jqueryVersion}.min.js"
+        f"https://cdnjs.cloudflare.com/ajax/libs/jquery/{jqueryVersionNumber}/jquery.min.js"
     )
 
     jqueryMapSourceURL = URL.fromText(
-        f"http://code.jquery.com/{jqueryVersion}.min.map"
+        f"https://cdnjs.cloudflare.com/ajax/libs/jquery/{jqueryVersionNumber}/jquery.min.map"
     )
 
     dataTablesSourceURL = URL.fromText(


### PR DESCRIPTION
# Overview

Goal is to fix an issue with the jQuery lib not getting cached by the server due to a download error when using TLS. This PR should download the lib from a different CDN `cdnjs.cloudflare.com` using TLS and cache it just like the `code.jquery.com` version was before this issue popped up.

 # WIP TODO
  - [x] Handle name change from different CDNs 

## Issues/Tasks

#1164 