### PR TITLE
feat: use text+datalist for "Add Ranger", rather than select

### DIFF
--- a/src/ims/element/incident/incident_template/template.xhtml
+++ b/src/ims/element/incident/incident_template/template.xhtml
@@ -73,13 +73,16 @@
         </ul>
         <div>
           <label class="control-label">Add:</label>
-          <select
+          <input
+            type="text"
             id="ranger_add"
+            list="ranger_handles"
             class="form-control input-sm auto-width"
             onchange="addRanger()"
-          >
+          />
+          <datalist id="ranger_handles">
             <option value="" />
-          </select>
+          </datalist>
         </div>
       </div>
     </div>

--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -547,7 +547,7 @@ function drawRangers() {
 
 
 function drawRangersToAdd() {
-    var select = $("#ranger_add");
+    var datalist = $("#ranger_handles");
 
     var handles = [];
     for (var handle in personnel) {
@@ -555,8 +555,8 @@ function drawRangersToAdd() {
     }
     handles.sort((a, b) => a.localeCompare(b));
 
-    select.empty();
-    select.append($("<option />"));
+    datalist.empty();
+    datalist.append($("<option />"));
 
     for (var i in handles) {
         var handle = handles[i];
@@ -566,7 +566,7 @@ function drawRangersToAdd() {
         option.val(handle);
         option.text(rangerAsString(ranger));
 
-        select.append(option);
+        datalist.append(option);
     }
 }
 
@@ -1000,6 +1000,12 @@ function addRanger() {
 
     if (handles.indexOf(handle) != -1) {
         // Already in the list, so… move along.
+        select.val("");
+        return;
+    }
+
+    if (!(handle in personnel)) {
+        // Not a valid handle
         select.val("");
         return;
     }


### PR DESCRIPTION
This has various benefits over the current select dropdown:

* You can search by substring, e.g. on a second word or on real names. The current way only lets you scan the dropdown with prefixes
* If you know the Ranger handles, you can just type them (e.g. "Abraham", enter, "Tool", enter, to add both of those callsigns)
* Removes the glitchy thing where you can accidentally add a bunch of random Rangers if you type while the select field is highlighted