### PR TITLE
feat: encourage user to log in with email address

### DIFF
--- a/src/ims/element/login/template.xhtml
+++ b/src/ims/element/login/template.xhtml
@@ -15,16 +15,16 @@
         </p>
 
         <div class="form-group">
-          <label for="username_input" class="col-sm-2 control-label">Ranger Handle:</label>
+          <label for="username_input" class="col-sm-2 control-label" title="Log in with either your Clubhouse email address or your case-sensitive Ranger handle">Email (or handle):</label>
           <div class="col-sm-3">
-            <input id="username_input" type="text" name="username" inputmode="latin-name" class="form-control" placeholder="Hold Me Closer" autocomplete="username" />
+            <input id="username_input" type="text" name="username" inputmode="latin-name" class="form-control" autocomplete="username" />
           </div>
         </div>
 
         <div class="form-group">
           <label for="password_input" class="col-sm-2 control-label">Password:</label>
           <div class="col-sm-3">
-            <input id="password_input" type="password" name="password" inputmode="latin-prose" class="form-control" placeholder="But not too close…" autocomplete="current-password" />
+            <input id="password_input" type="password" name="password" inputmode="latin-prose" class="form-control" autocomplete="current-password" />
           </div>
         </div>
 


### PR DESCRIPTION
This is a purely cosmetic change, since both email address and handle currently work for logging into IMS.

I observed directly many people struggle to log in with their handles, since they'd either get the capitalization wrong or they'd mess up the presence of spaces/dashes.

People are already more comfortable with logging in with their email addresses, since that's how they do it in the Clubhouse. This aligns Clubhouse and IMS a bit better.

The "title" addition gives an alt-text style popup if you hover over the "Email (or handle)" text.

<img width="568" alt="image" src="https://github.com/user-attachments/assets/b2282525-a98c-461f-8fd0-3979aa63e50f">
