### PR TITLE
Don't hard code timeout on IMSSession, duh.

### DIFF
--- a/src/ims/application/_api.py
+++ b/src/ims/application/_api.py
@@ -204,7 +204,7 @@ class APIApplication:
             else:
                 self._log.info("Issuing credentials for user {user}", user=user)
                 credentials = await authProvider.credentialsForUser(
-                    user, self.config.tokenLifetimeNormal
+                    user, self.config.tokenLifetime
                 )
                 return jsonBytes(
                     request, jsonTextFromObject(credentials).encode("utf-8")

--- a/src/ims/config/_config.py
+++ b/src/ims/config/_config.py
@@ -388,23 +388,13 @@ class Configuration:
 
         masterKey = parser.valueFromConfig("MASTER_KEY", "Core", "MasterKey")
 
-        tokenLifetimeNormal = TimeDelta(
+        tokenLifetime = TimeDelta(
             seconds=int(
                 parser.valueFromConfig(
-                    "TOKEN_LIFETIME_NORMAL",
+                    "TOKEN_LIFETIME",
                     "Core",
                     "TokenLifetime",
                     str(1 * 60 * 60),
-                )
-            )
-        )
-        tokenLifetimeExtended = TimeDelta(
-            seconds=int(
-                parser.valueFromConfig(
-                    "TOKEN_LIFETIME_EXTENDED",
-                    "Core",
-                    "TokenLifetime",
-                    str(30 * 24 * 60 * 60),
                 )
             )
         )
@@ -430,8 +420,7 @@ class Configuration:
             requireActive=requireActive,
             serverRoot=serverRoot,
             storeFactory=storeFactory,
-            tokenLifetimeExtended=tokenLifetimeExtended,
-            tokenLifetimeNormal=tokenLifetimeNormal,
+            tokenLifetime=tokenLifetime,
         )
 
     cachedResourcesRoot: Path
@@ -449,8 +438,7 @@ class Configuration:
     port: int
     requireActive: bool
     serverRoot: Path
-    tokenLifetimeExtended: TimeDelta
-    tokenLifetimeNormal: TimeDelta
+    tokenLifetime: TimeDelta
 
     _storeFactory: Callable[[], IMSDataStore]
 

--- a/src/ims/run/_command.py
+++ b/src/ims/run/_command.py
@@ -55,10 +55,6 @@ from ._options import (
 __all__ = ()
 
 
-class IMSSession(Session):
-    sessionTimeout = 60 * 60 * 1  # 1 hour
-
-
 @frozen(kw_only=True)
 class Command:
     """
@@ -106,6 +102,9 @@ class Command:
         )
 
         patchCombinedLogFormatter()
+
+        class IMSSession(Session):
+            sessionTimeout = int(config.tokenLifetime.total_seconds())
 
         factory = Site(application.router.resource())
         factory.sessionFactory = IMSSession


### PR DESCRIPTION
Don't hard code timeout on `IMSSession`; use same value as JWT token timeout.

Change `IMS_TOKEN_LIFETIME_NORMAL` to `IMS_TOKEN_LIFETIME`.
Remove unused `IMS_TOKEN_LIFETIME_EXTENDED`.
