### PR TITLE
feat: don't serialize personnel email to JSON

### DIFF
--- a/src/ims/model/_ranger.py
+++ b/src/ims/model/_ranger.py
@@ -73,7 +73,9 @@ class Ranger(ReplaceMixIn):
     handle: str
     name: str
     status: RangerStatus
-    email: frozenset[str] = field(converter=freezeStrings)
+    email: frozenset[str] = field(
+        converter=freezeStrings, default=frozenset[str]()
+    )
     enabled: bool
     directoryID: str | None
     password: str | None = field(

--- a/src/ims/model/json/_ranger.py
+++ b/src/ims/model/json/_ranger.py
@@ -42,9 +42,10 @@ class RangerJSONKey(Enum):
     handle = "handle"
     name = "name"
     status = "status"
-    email = "email"
+    # email is intentionally not serialized, since no web client needs it
     enabled = "enabled"
     directoryID = "directory_id"
+    # password is intentionally not serialized, since no web client needs it
 
 
 class RangerJSONType(Enum):
@@ -55,9 +56,10 @@ class RangerJSONType(Enum):
     handle = str
     name = str  # type: ignore[assignment]
     status = RangerStatus
-    email = set[str]
+    # email is intentionally not serialized, since no web client needs it
     enabled = bool
     directoryID = Optional[str]
+    # password is intentionally not serialized, since no web client needs it
 
 
 def serializeRanger(ranger: Ranger) -> dict[str, Any]:

--- a/src/ims/model/json/test/json.py
+++ b/src/ims/model/json/test/json.py
@@ -186,9 +186,10 @@ def jsonFromRanger(ranger: Ranger) -> dict[str, Any]:
         handle=ranger.handle,
         name=ranger.name,
         status=jsonFromRangerStatus(ranger.status),
-        directory_id=ranger.directoryID,
-        email=jsonSerialize([e for e in ranger.email]),
+        # email is intentionally not serialized
         enabled=ranger.enabled,
+        directory_id=ranger.directoryID,
+        # password is intentionally not serialized
     )
 
 

--- a/src/ims/model/json/test/test_ranger.py
+++ b/src/ims/model/json/test/test_ranger.py
@@ -56,5 +56,8 @@ class RangerDeserializationTests(TestCase):
         """
         self.assertEqual(
             jsonDeserialize(jsonFromRanger(ranger), Ranger),
-            ranger.replace(password=None),
+            ranger.replace(
+                email=frozenset(),
+                password=None,
+            ),
         )


### PR DESCRIPTION
We have an authenticated API endpoint that lists all Rangers' handles, names, and email addresses. That endpoint is currently only used to serve the "Add Rangers" functionality on the incident page. Nothing in the UI requires use of these email addresses. We can get a nice little privacy win by not exposing them anymore. Note that this PR uses the same approach to not serializing email that we already use to not serialize passwords.

See here for an example of personnel (requires login):
https://ranger-ims.burningman.org/ims/api/personnel/

and note that no JS code references email:
https://github.com/search?q=repo%3Aburningmantech%2Franger-ims-server%20lang%3Ajs+email&type=code

and that the JS code in ranger-ims-web does expect the email field, but it doesn't use it anywhere:
https://github.com/search?q=repo%3Aburningmantech%2Franger-ims-web%20lang%3Ajs+email&type=code