### PR TITLE
feat: allow more than 6 tabs per browser session

### DIFF
--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -46,20 +46,17 @@ function initIncidentPage() {
         loadAndDisplayIncident(loadedIncident);
 
         // Updates
+        requestEventSourceLock();
 
-        subscribeToUpdates();
-
-        eventSource.addEventListener("Incident", function(e) {
-            var jsonText = e.data;
-            var json = JSON.parse(jsonText);
-            var number = json["incident_number"];
-
+        const incidentChannel = new BroadcastChannel(incidentChannelName);
+        incidentChannel.onmessage = function (e) {
+            const number = e.data;
             if (number == incidentNumber) {
-                console.log("Got incident update");
+                console.log("Got incident update: " + number);
                 loadAndDisplayIncident();
                 loadAndDisplayIncidentReports();
             }
-        }, true);
+        }
 
         // Keyboard shortcuts
 

--- a/src/ims/element/static/incident_reports.js
+++ b/src/ims/element/static/incident_reports.js
@@ -75,16 +75,14 @@ function initIncidentReportsTable() {
         enableEditing();
     }
 
-    subscribeToUpdates();
+    requestEventSourceLock();
 
-    eventSource.addEventListener("IncidentReport", function(e) {
-        var jsonText = e.data;
-        var json = JSON.parse(jsonText);
-        var number = json["incident_report_number"];
-
+    const incidentReportChannel = new BroadcastChannel(incidentReportChannelName);
+    incidentReportChannel.onmessageonmessage = function (e) {
+        const number = e.data;
         console.log("Got incident report update: " + number);
         incidentReportsTable.ajax.reload();
-    }, true);
+    }
 }
 
 

--- a/src/ims/element/static/incidents.js
+++ b/src/ims/element/static/incidents.js
@@ -113,16 +113,14 @@ function initIncidentsTable() {
         enableEditing();
     }
 
-    subscribeToUpdates();
+    requestEventSourceLock();
 
-    eventSource.addEventListener("Incident", function(e) {
-        var jsonText = e.data;
-        var json = JSON.parse(jsonText);
-        var number = json["incident_number"];
-
+    const incidentChannel = new BroadcastChannel(incidentChannelName);
+    incidentChannel.onmessage = function (e) {
+        const number = e.data;
         console.log("Got incident update: " + number);
         incidentsTable.ajax.reload();
-    }, true);
+    }
 }
 
 


### PR DESCRIPTION
I was inspired by this comment on Reddit (the first in the list):
https://www.reddit.com/r/webdev/comments/149bjod/comment/kwm0742/

Rather than having each tab establish an eventsource connection
individually, this changes it so that all tabs share one eventsource.
That's done by having one tab become the leader (Web Locks API),
then having it fan out updates to all the other tabs in the session
(Broadcast Channel API).