### PR TITLE
feat: display errors on pages rather than with browser alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Each month below should look like the following, using the same ordering for the
 ### Fixed
 
 - Stopped using hardcoded 1-hour limit on IMS sessions; used timeout from JWT instead ([#1301](https://github.com/burningmantech/ranger-ims-server/pull/1301))
+- Got rid of the browser popup alerts that occurred frequently on JavaScript errors. Instead, error messages will now be written to a text field near the top of each page ([#1335](https://github.com/burningmantech/ranger-ims-server/pull/1335))
 
 ## 2024-01
 

--- a/src/ims/element/incident/incident_template/template.xhtml
+++ b/src/ims/element/incident/incident_template/template.xhtml
@@ -1,6 +1,10 @@
 <!DOCTYPE html>
 <div xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" t:render="container">
 
+  <div id="error_info" class="hidden text-danger">
+    <p id="error_text"></p>
+  </div>
+
   <!-- Incident number, state, priority -->
 
   <div class="row">

--- a/src/ims/element/incident/incidents_template/template.xhtml
+++ b/src/ims/element/incident/incidents_template/template.xhtml
@@ -1,5 +1,10 @@
 <!DOCTYPE html>
 <div xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" t:render="container">
+
+  <div id="error_info" class="hidden text-danger">
+    <p id="error_text"></p>
+  </div>
+
   <p>
     <a href="../incident_reports/">
       <span class="glyphicon glyphicon-arrow-right" /> Incident Reports

--- a/src/ims/element/incident/report_template/template.xhtml
+++ b/src/ims/element/incident/report_template/template.xhtml
@@ -1,5 +1,10 @@
 <!DOCTYPE html>
 <div xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" t:render="container">
+
+  <div id="error_info" class="hidden text-danger">
+    <p id="error_text"></p>
+  </div>
+
   <div class="row">
       <div class="col-sm-4 text-left">
         <div class="form-group">

--- a/src/ims/element/incident/reports_template/template.xhtml
+++ b/src/ims/element/incident/reports_template/template.xhtml
@@ -1,5 +1,10 @@
 <!DOCTYPE html>
 <div xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" t:render="container">
+
+  <div id="error_info" class="hidden text-danger">
+    <p id="error_text"></p>
+  </div>
+
   <p>
     <a href="../incidents/">
       <span class="glyphicon glyphicon-arrow-right" /> Incidents

--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -122,9 +122,9 @@ function loadIncident(success) {
 
     function fail(error, status, xhr) {
         disableEditing();
-        var message = "Failed to load incident:\n" + error;
-        console.error(message);
-        window.alert(message);
+        var message = "Failed to load incident";
+        console.error(message + ": " + error);
+        setErrorMessage(message);
     }
 
     if (number == null) {
@@ -140,17 +140,30 @@ function loadIncident(success) {
     }
 }
 
+// Set the user-visible error information on the page to the provided
+// string, or clear the information if the parameter is falsy.
+function setErrorMessage(msg) {
+    if (msg) {
+        msg = "Error: Please reload this page. (" + msg + ")"
+        $("#error_info").removeClass("hidden");
+        $("#error_text").text(msg);
+    } else {
+        $("#error_info").addClass("hidden");
+        $("#error_text").text("");
+    }
+}
 
 function loadAndDisplayIncident(success) {
     function loaded() {
         if (incident == null) {
             var message = "Incident failed to load";
             console.log(message);
-            alert(message);
+            setErrorMessage(message);
             return;
         }
 
         drawIncidentFields();
+        setErrorMessage("");
 
         if (editingAllowed) {
             enableEditing();
@@ -227,9 +240,9 @@ function loadPersonnel(success) {
     }
 
     function fail(error, status, xhr) {
-        var message = "Failed to load personnel:\n" + error;
-        console.error(message);
-        window.alert(message);
+        var message = "Failed to load personnel";
+        console.error(message + ": " + error);
+        setErrorMessage(message);
     }
 
     jsonRequest(url_personnel, null, ok, fail);
@@ -289,9 +302,9 @@ function loadIncidentTypes(success) {
     }
 
     function fail(error, status, xhr) {
-        var message = "Failed to load incident types:\n" + error;
-        console.error(message);
-        window.alert(message);
+        var message = "Failed to load incident types";
+        console.error(message + ": " + error);
+        setErrorMessage(message);
     }
 
     jsonRequest(url_incidentTypes, null, ok, fail);
@@ -345,11 +358,9 @@ function loadUnattachedIncidentReports(success) {
             // We're not allowed to look these up.
             unattachedIncidentReports = undefined;
         } else {
-            var message = (
-                "Failed to load unattached incident reports:\n" + error
-            );
-            console.error(message);
-            window.alert(message);
+            var message = "Failed to load unattached incident reports";
+            console.error(message + ": " + error);
+            setErrorMessage(message);
         }
     }
 
@@ -380,9 +391,9 @@ function loadAttachedIncidentReports(success) {
     }
 
     function fail(error, status, xhr) {
-        var message = "Failed to load attached incident reports:\n" + error;
-        console.error(message);
-        window.alert(message);
+        var message = "Failed to load attached incident reports";
+        console.error(message + ": " + error);
+        setErrorMessage(message);
     }
 
     var url = (
@@ -890,11 +901,11 @@ function sendEdits(edits, success, error) {
     }
 
     function fail(requestError, status, xhr) {
-        var message = "Failed to apply edit:\n" + requestError
-        console.log(message);
+        var message = "Failed to apply edit";
+        console.log(message + ": " + requestError);
         error();
         loadAndDisplayIncident();
-        window.alert(message);
+        setErrorMessage(message);
     }
 
     jsonRequest(url, edits, ok, fail);
@@ -1100,10 +1111,10 @@ function detachIncidentReport(sender) {
         // FIXME
         // controlHasError(sender);
 
-        var message = "Failed to detach incident report:\n" + requestError
-        console.log(message);
+        var message = "Failed to detach incident report";
+        console.log(message + ": " + requestError);
         loadAndDisplayIncidentReports();
-        window.alert(message);
+        setErrorMessage(message);
     }
 
     var url = (
@@ -1130,10 +1141,10 @@ function attachIncidentReport() {
     }
 
     function fail(requestError, status, xhr) {
-        var message = "Failed to attach incident report:\n" + requestError
-        console.log(message);
+        var message = "Failed to attach incident report";
+        console.log(message + ": " + requestError);
         loadAndDisplayIncidentReports();
-        window.alert(message);
+        setErrorMessage(message);
     }
 
     var url = (

--- a/src/ims/element/static/incident_report.js
+++ b/src/ims/element/static/incident_report.js
@@ -72,6 +72,19 @@ function initIncidentReportPage() {
     loadBody(loadedBody);
 }
 
+// Set the user-visible error information on the page to the provided
+// string, or clear the information if the parameter is falsy.
+function setErrorMessage(msg) {
+    if (msg) {
+        msg = "Error: Please reload this page. (" + msg + ")"
+        $("#error_info").removeClass("hidden");
+        $("#error_text").text(msg);
+    } else {
+        $("#error_info").addClass("hidden");
+        $("#error_text").text("");
+    }
+}
+
 
 //
 // Load incident report
@@ -99,9 +112,9 @@ function loadIncidentReport(success) {
 
     function fail(error, status, xhr) {
         disableEditing();
-        var message = "Failed to load incident report:\n" + error;
-        console.error(message);
-        window.alert(message);
+        var message = "Failed to load incident report";
+        console.error(message + ": " + error);
+        setErrorMessage(message);
     }
 
     if (number == null) {
@@ -121,7 +134,7 @@ function loadAndDisplayIncidentReport(success) {
         if (incidentReport == null) {
             var message = "Incident report failed to load";
             console.log(message);
-            alert(message);
+            setErrorMessage(message);
             return;
         }
 
@@ -129,6 +142,7 @@ function loadAndDisplayIncidentReport(success) {
         drawNumber();
         drawSummary();
         drawReportEntries(incidentReport.report_entries);
+        setErrorMessage("");
 
         $("#incident_report_add").on("input", reportEntryEdited);
 
@@ -252,11 +266,11 @@ function sendEdits(edits, success, error) {
     }
 
     function fail(requestError, status, xhr) {
-        var message = "Failed to apply edit:\n" + requestError
-        console.log(message);
+        var message = "Failed to apply edit";
+        console.log(message + ": " + requestError);
         error();
         loadAndDisplayIncidentReport();
-        window.alert(message);
+        setErrorMessage(message);
     }
 
     jsonRequest(url, edits, ok, fail);


### PR DESCRIPTION
I wrote a lot more about this in the linked issue. The short story is that IMS uses browser alert popups almost every time something goes wrong. Those become menaces when the user's session is no longer valid, but when there are still browser tabs open to IMS, because the SSEs keep coming through, encouraging those tabs to reload data they won't be able to load.
https://github.com/burningmantech/ranger-ims-server/issues/1327

This instead puts red error text at the top of a page when an error has occurred. I had to do some unexpected work to get the DataTables part to stop alerting, because DataTables itself normally fires alerts on errors too.

Example:
<img width="618" alt="image" src="https://github.com/user-attachments/assets/b7d98d27-5fc4-437e-b725-07183cbf2d28">
