### PR TITLE
fix: don't throw DataTables errors

### DIFF
--- a/src/ims/element/static/incident_reports.js
+++ b/src/ims/element/static/incident_reports.js
@@ -108,7 +108,7 @@ function initDataTables() {
         return incidentReports;
     }
 
-    $.fn.dataTable.ext.errMode = "throw";
+    $.fn.dataTable.ext.errMode = "none";
     incidentReportsTable = $("#incident_reports_table").DataTable({
         "deferRender": true,
         "paging": true,

--- a/src/ims/element/static/incidents.js
+++ b/src/ims/element/static/incidents.js
@@ -145,7 +145,7 @@ function initDataTables() {
         return incidents;
     }
 
-    $.fn.dataTable.ext.errMode = "throw";
+    $.fn.dataTable.ext.errMode = "none";
     incidentsTable = $("#queue_table").DataTable({
         "deferRender": true,
         "paging": true,


### PR DESCRIPTION
This previously seemed to just cause the page to hang on "processing" when I tried to produce a DataTables load issue in staging (rather than correctly setting the error text). It worked locally though... I think the problem is that we're throwing the error now and it's not being caught by anything. Using "none" seems to work locally too, so let's try it out in staging.