### PR TITLE
fix: try again to show error message on incidents page

### DIFF
--- a/src/ims/element/static/incident_reports.js
+++ b/src/ims/element/static/incident_reports.js
@@ -81,7 +81,7 @@ function initIncidentReportsTable() {
     incidentReportChannel.onmessage = function (e) {
         const number = e.data;
         console.log("Got incident report update: " + number);
-        incidentReportsTable.ajax.reload();
+        incidentReportsTable.ajax.reload(clearErrorMessage);
     }
 }
 
@@ -98,13 +98,16 @@ function setErrorMessage(msg) {
     }
 }
 
+function clearErrorMessage() {
+    setErrorMessage("");
+}
+
 //
 // Initialize DataTables
 //
 
 function initDataTables() {
     function dataHandler(incidentReports) {
-        setErrorMessage("");
         return incidentReports;
     }
 

--- a/src/ims/element/static/incidents.js
+++ b/src/ims/element/static/incidents.js
@@ -91,7 +91,7 @@ function loadEventIncidentReports(success) {
 
     console.log("Loaded event incident reports");
     if (incidentsTable != null) {
-        incidentsTable.ajax.reload();
+        incidentsTable.ajax.reload(clearErrorMessage);
     }
 }
 
@@ -106,6 +106,10 @@ function setErrorMessage(msg) {
         $("#error_info").addClass("hidden");
         $("#error_text").text("");
     }
+}
+
+function clearErrorMessage() {
+    setErrorMessage("");
 }
 
 //
@@ -130,7 +134,7 @@ function initIncidentsTable() {
     incidentChannel.onmessage = function (e) {
         const number = e.data;
         console.log("Got incident update: " + number);
-        incidentsTable.ajax.reload();
+        incidentsTable.ajax.reload(clearErrorMessage);
     }
 }
 
@@ -141,7 +145,6 @@ function initIncidentsTable() {
 
 function initDataTables() {
     function dataHandler(incidents) {
-        setErrorMessage("");
         return incidents;
     }
 


### PR DESCRIPTION
The change in https://github.com/burningmantech/ranger-ims-server/pull/1338 didn't suffice. I think this has a good chance though. I think in the AWS case, we're calling the dataSrc handler with an empty set of data, calling the line that clears the error text.

This tweak might fix it. It's annoying this behaves differently on errors on AWS vs locally.