### PR TITLE
fix: actually set the error text on each page

### DIFF
--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -140,17 +140,16 @@ function loadIncident(success) {
     }
 }
 
-// Set the user-visible error information on the page to the provided
-// string, or clear the information if the parameter is falsy.
+// Set the user-visible error information on the page to the provided string.
 function setErrorMessage(msg) {
-    if (msg) {
-        msg = "Error: Please reload this page. (" + msg + ")"
-        $("#error_info").removeClass("hidden");
-        $("#error_text").text(msg);
-    } else {
-        $("#error_info").addClass("hidden");
-        $("#error_text").text("");
-    }
+    msg = "Error: Please reload this page. (Cause: " + msg + ")"
+    $("#error_info").removeClass("hidden");
+    $("#error_text").text(msg);
+}
+
+function clearErrorMessage() {
+    $("#error_info").addClass("hidden");
+    $("#error_text").text("");
 }
 
 function loadAndDisplayIncident(success) {
@@ -163,7 +162,7 @@ function loadAndDisplayIncident(success) {
         }
 
         drawIncidentFields();
-        setErrorMessage("");
+        clearErrorMessage();
 
         if (editingAllowed) {
             enableEditing();

--- a/src/ims/element/static/incident_report.js
+++ b/src/ims/element/static/incident_report.js
@@ -72,17 +72,16 @@ function initIncidentReportPage() {
     loadBody(loadedBody);
 }
 
-// Set the user-visible error information on the page to the provided
-// string, or clear the information if the parameter is falsy.
+// Set the user-visible error information on the page to the provided string.
 function setErrorMessage(msg) {
-    if (msg) {
-        msg = "Error: Please reload this page. (" + msg + ")"
-        $("#error_info").removeClass("hidden");
-        $("#error_text").text(msg);
-    } else {
-        $("#error_info").addClass("hidden");
-        $("#error_text").text("");
-    }
+    msg = "Error: Please reload this page. (Cause: " + msg + ")"
+    $("#error_info").removeClass("hidden");
+    $("#error_text").text(msg);
+}
+
+function clearErrorMessage() {
+    $("#error_info").addClass("hidden");
+    $("#error_text").text("");
 }
 
 
@@ -142,7 +141,7 @@ function loadAndDisplayIncidentReport(success) {
         drawNumber();
         drawSummary();
         drawReportEntries(incidentReport.report_entries);
-        setErrorMessage("");
+        clearErrorMessage();
 
         $("#incident_report_add").on("input", reportEntryEdited);
 

--- a/src/ims/element/static/incident_reports.js
+++ b/src/ims/element/static/incident_reports.js
@@ -70,7 +70,7 @@ function initIncidentReportsTable() {
     initTableButtons();
     initSearchField();
     initSearch();
-    setErrorMessage("");
+    clearErrorMessage();
 
     if (editingAllowed) {
         enableEditing();
@@ -85,21 +85,16 @@ function initIncidentReportsTable() {
     }
 }
 
-// Set the user-visible error information on the page to the provided
-// string, or clear the information if the parameter is falsy.
+// Set the user-visible error information on the page to the provided string.
 function setErrorMessage(msg) {
-    if (msg) {
-        msg = "Error: Please reload this page. (" + msg + ")"
-        $("#error_info").removeClass("hidden");
-        $("#error_text").text(msg);
-    } else {
-        $("#error_info").addClass("hidden");
-        $("#error_text").text("");
-    }
+    msg = "Error: Please reload this page. (Cause: " + msg + ")"
+    $("#error_info").removeClass("hidden");
+    $("#error_text").text(msg);
 }
 
 function clearErrorMessage() {
-    setErrorMessage("");
+    $("#error_info").addClass("hidden");
+    $("#error_text").text("");
 }
 
 //
@@ -130,7 +125,15 @@ function initDataTables() {
                 if (error == "abort") {
                     return;
                 }
-                setErrorMessage(error);
+                let errMsg = "";
+                if (error) {
+                    errMsg = error;
+                } else if (request.responseText) {
+                    errMsg = request.responseText;
+                } else {
+                    errMsg = "DataTables error";
+                }
+                setErrorMessage(errMsg);
             },
         },
         "columns": [

--- a/src/ims/element/static/incidents.js
+++ b/src/ims/element/static/incidents.js
@@ -95,21 +95,16 @@ function loadEventIncidentReports(success) {
     }
 }
 
-// Set the user-visible error information on the page to the provided
-// string, or clear the information if the parameter is falsy.
+// Set the user-visible error information on the page to the provided string.
 function setErrorMessage(msg) {
-    if (msg) {
-        msg = "Error: Please reload this page. (" + msg + ")"
-        $("#error_info").removeClass("hidden");
-        $("#error_text").text(msg);
-    } else {
-        $("#error_info").addClass("hidden");
-        $("#error_text").text("");
-    }
+    msg = "Error: Please reload this page. (Cause: " + msg + ")"
+    $("#error_info").removeClass("hidden");
+    $("#error_text").text(msg);
 }
 
 function clearErrorMessage() {
-    setErrorMessage("");
+    $("#error_info").addClass("hidden");
+    $("#error_text").text("");
 }
 
 //
@@ -123,7 +118,7 @@ function initIncidentsTable() {
     initTableButtons();
     initSearchField();
     initSearch();
-    setErrorMessage("");
+    clearErrorMessage();
 
     if (editingAllowed) {
         enableEditing();
@@ -167,7 +162,15 @@ function initDataTables() {
                 if (error == "abort") {
                     return;
                 }
-                setErrorMessage(error);
+                let errMsg = "";
+                if (error) {
+                    errMsg = error;
+                } else if (request.responseText) {
+                    errMsg = request.responseText;
+                } else {
+                    errMsg = "DataTables error";
+                }
+                setErrorMessage(errMsg);
             },
         },
         "columns": [


### PR DESCRIPTION
I finally figured out why the error text wasn't showing up in my testing in staging. It turns out the error handler in DataTables was getting an error of "", meaning setErrorMessage was actually clearing the error message. This change should fix that.

See also
https://github.com/burningmantech/ranger-ims-server/pull/1339 https://github.com/burningmantech/ranger-ims-server/pull/1338