### PR TITLE
fix(.github): skip no-commit-to-branch on cicd workflow

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -55,6 +55,11 @@ jobs:
 
       - name: Run Linters
         run: tox run -e lint
+        env:
+          # no-commit-to-branch always fails in CI, because this pre-commit
+          # is only designed for running locally (i.e. when committing to a
+          # local master branch)
+          SKIP: no-commit-to-branch
 
 
   mypy:


### PR DESCRIPTION
This pre-commit is designed for local use, i.e. when you try to commit to a specific branch locally. It doesn't make sense to run this when actually trying to merge a commit to master via CICD, since it'll always fail.

See that all of our CI/CD workflows fail for this reason: https://github.com/burningmantech/ranger-ims-server/actions?query=branch%3Amaster

Note that this is commonly skipped in other people's GitHub workflows: https://sourcegraph.com/search?q=context:global+f:.github/workflows+content:no-commit-to-branch&patternType=regexp&sm=0