### PR TITLE
docs(js): add a comment to incidents.js

### DIFF
--- a/src/ims/element/static/incidents.js
+++ b/src/ims/element/static/incidents.js
@@ -62,6 +62,9 @@ function initIncidentsPage() {
 //
 // Load event incident reports
 //
+// Note that nothing from these data is displayed in the incidents table.
+// We do this fetch in order to make incidents searchable by text in their
+// attached incident reports.
 
 var eventIncidentReports = null;
 


### PR DESCRIPTION
It took me a while to figure out why this file was loading incident reports, especially since I was able to entirely remove this code and see the incidents table still work.