### PR TITLE
Try to get a green checkmark even though an optional job failed

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -261,7 +261,6 @@ jobs:
           path: .tox/${TOX_ENV}/log/trial.log
 
       - name: Clear prior optional job failed comment, if any
-        if: ${{ steps.test.outputs.optional_fail == 'true' }}
         uses: thollander/actions-comment-pull-request@v3
         with:
           comment-tag: "${{ matrix.python-version }}-${{ matrix.os }}-optional-notice"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -263,7 +263,7 @@ jobs:
           path: .tox/${TOX_ENV}/log/trial.log
 
       - name: Add comment if optional job failed
-        if: {{ steps.test.outputs.optional_fail == 'true' }}
+        if: ${{ steps.test.outputs.optional_fail == 'true' }}
         uses: thollander/actions-comment-pull-request@v3
         with:
           comment_tag: "${{ matrix.python-version }}-${{ matrix.os }}-optional-notice"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -266,8 +266,8 @@ jobs:
         if: ${{ steps.test.outputs.optional_fail == 'true' }}
         uses: thollander/actions-comment-pull-request@v3
         with:
-          comment_tag: "${{ matrix.python-version }}-${{ matrix.os }}-optional-notice"
-          filePath: "${GITHUB_STEP_SUMMARY}"
+          comment-tag: "${{ matrix.python-version }}-${{ matrix.os }}-optional-notice"
+          file-path: "${GITHUB_STEP_SUMMARY}"
 
       # Use the latest supported Python version for combining coverage to
       # prevent parsing errors in older versions when looking at modern code.

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -260,21 +260,17 @@ jobs:
           name: trial
           path: .tox/${TOX_ENV}/log/trial.log
 
-      - name: Clear prior optional job failed comment, if any
+      - name: Add comment if optional job failed; delete otherwise
+        if: ${{ matrix.optional }}
         uses: thollander/actions-comment-pull-request@v3
         with:
+          # Note: tag must be unique to each matrix case
           comment-tag: "${{ matrix.python-version }}-${{ matrix.os }}-optional-notice"
-          mode: delete
-
-      # - name: Add comment if optional job failed
-      #   if: ${{ steps.test.outputs.optional_fail == 'true' }}
-      #   uses: thollander/actions-comment-pull-request@v3
-      #   with:
-      #     comment-tag: "${{ matrix.python-version }}-${{ matrix.os }}-optional-notice"
-      #     message: |
-      #       ### Optional matrix job Py:${{ matrix.python-version }} - ${{ matrix.os }} failed!
-      #        - tox prefix: ${{ matrix.tox-prefix }}
-      #        - exit status: ${{ steps.test.outputs.optional_fail_status }}
+          message: |
+            ### ⚠️ Optional matrix job Py:${{ matrix.python-version }} - ${{ matrix.os }} failed ⚠️
+             - tox prefix: ${{ matrix.tox-prefix }}
+             - exit status: ${{ steps.test.outputs.optional_fail_status }}
+          mode: ${{ steps.test.outputs.optional_fail == 'true' && 'upsert' || 'delete' }}
 
       # Use the latest supported Python version for combining coverage to
       # prevent parsing errors in older versions when looking at modern code.

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -237,15 +237,14 @@ jobs:
       - name: Run unit tests
         id: test
         run: |
-          if ! tox run -e ${TOX_ENV}; then
-            status=$?
-            if [ "${{ matrix.optional }}" == "true" ]; then
-              echo "::warning::Optional matrix job failed."
-              echo "optional_fail=true" >> "${GITHUB_OUTPUT}"
-              echo "optional_fail_status=${status}" >> "${GITHUB_OUTPUT}"
-            fi;
-            exit ${status}
+          status=0
+          tox run -e "${TOX_ENV}" || status=$?
+          if [ ! ${status} && "${{ matrix.optional }}" == "true" ]; then
+            echo "::warning::Optional matrix job failed."
+            echo "optional_fail=true" >> "${GITHUB_OUTPUT}"
+            echo "optional_fail_status=${status}" >> "${GITHUB_OUTPUT}"
           fi;
+          exit ${status}
         env:
           IMS_TEST_MYSQL_HOST: localhost
           IMS_TEST_MYSQL_PORT: ${{ job.services.mysql.ports['3306'] }}
@@ -266,7 +265,7 @@ jobs:
         with:
           comment-tag: "${{ matrix.python-version }}-${{ matrix.os }}-optional-notice"
           message: |
-            ### Optional matrix job Py:${{ matrix.python-version }} - ${{ matrix.os }} failed
+            ### Optional matrix job Py:${{ matrix.python-version }} - ${{ matrix.os }} failed!
              - tox prefix: ${{ matrix.tox-prefix }}
              - exit status: ${{ steps.test.outputs.optional_fail_status }}
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -243,7 +243,7 @@ jobs:
               echo "optional_fail=true" >> "${GITHUB_OUTPUT}"
               echo "### Optional matrix job Py:${{ matrix.python-version }} - ${{ matrix.os }} failed" >> "${GITHUB_STEP_SUMMARY}"
               echo " - tox-prefix: ${{ matrix.tox-prefix }}"
-              echo " - exit status: "${status}" >> "${GITHUB_STEP_SUMMARY}"
+              echo " - exit status: ${status}" >> "${GITHUB_STEP_SUMMARY}"
             fi;
             exit ${status}
           fi;

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -243,7 +243,7 @@ jobs:
               echo "::warning::Optional matrix job failed."
               echo "optional_fail=true" >> "${GITHUB_OUTPUT}"
               echo "### Optional matrix job Py:${{ matrix.python-version }} - ${{ matrix.os }} failed" >> "${GITHUB_STEP_SUMMARY}"
-              echo " - tox-prefix: ${{ matrix.tox-prefix }}"
+              echo " - tox-prefix: ${{ matrix.tox-prefix }}" >> "${GITHUB_STEP_SUMMARY}"
               echo " - exit status: ${status}" >> "${GITHUB_STEP_SUMMARY}"
             fi;
             exit ${status}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -262,6 +262,13 @@ jobs:
           name: trial
           path: .tox/${TOX_ENV}/log/trial.log
 
+      - name: Add comment if optional job failed
+        if: {{ steps.test.outputs.optional_fail == 'true' }}
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          comment_tag: "${{ matrix.python-version }}-${{ matrix.os }}-optional-notice"
+          filePath: "${GITHUB_STEP_SUMMARY}"
+
       # Use the latest supported Python version for combining coverage to
       # prevent parsing errors in older versions when looking at modern code.
       - uses: "actions/setup-python@v5"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -238,7 +238,9 @@ jobs:
         run: |
           if ! tox run -e ${TOX_ENV}; then
             status=$?
-            echo "${{ matrix.optional }}"
+            if [ "${{ matrix.optional }}" == "true" ]; then
+              echo "::warning::Optional matrix job failed.";
+            fi;
             exit ${status}
           fi;
         env:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -256,7 +256,7 @@ jobs:
           IMS_TEST_MYSQL_PASSWORD: ims
 
       - name: Upload Trial log artifact
-        if: ${{ failure() || steps.test.outputs.optional_fail == "true" }}
+        if: ${{ failure() || steps.test.outputs.optional_fail == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: trial

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -235,7 +235,12 @@ jobs:
           tox run -e lint --notest
 
       - name: Run unit tests
-        run: tox run -e ${TOX_ENV}
+        run:
+          if ! tox run -e ${TOX_ENV}; then
+            status=$?
+            echo "${{ matrix.optional }}"
+            exit ${status}
+          fi;
         env:
           IMS_TEST_MYSQL_HOST: localhost
           IMS_TEST_MYSQL_PORT: ${{ job.services.mysql.ports['3306'] }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -243,6 +243,7 @@ jobs:
             echo "::warning::Optional matrix job failed."
             echo "optional_fail=true" >> "${GITHUB_OUTPUT}"
             echo "optional_fail_status=${status}" >> "${GITHUB_OUTPUT}"
+            exit 0  # Ignore error here to keep the green checkmark going
           fi;
           exit ${status}
         env:
@@ -253,19 +254,21 @@ jobs:
           IMS_TEST_MYSQL_PASSWORD: ims
 
       - name: Upload Trial log artifact
+        if: ${{ failure() || steps.test.outputs.optional_fail == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: trial
           path: .tox/${TOX_ENV}/log/trial.log
 
       - name: Clear prior optional job failed comment, if any
+        if: ${{ steps.test.outputs.optional_fail == 'true' }}
         uses: thollander/actions-comment-pull-request@v3
         with:
           comment-tag: "${{ matrix.python-version }}-${{ matrix.os }}-optional-notice"
           mode: delete
 
       # - name: Add comment if optional job failed
-      #   if: ${{ failure() && steps.test.outputs.optional_fail == 'true' }}
+      #   if: ${{ steps.test.outputs.optional_fail == 'true' }}
       #   uses: thollander/actions-comment-pull-request@v3
       #   with:
       #     comment-tag: "${{ matrix.python-version }}-${{ matrix.os }}-optional-notice"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -235,7 +235,7 @@ jobs:
           tox run -e lint --notest
 
       - name: Run unit tests
-        run:
+        run: |
           if ! tox run -e ${TOX_ENV}; then
             status=$?
             echo "${{ matrix.optional }}"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -242,9 +242,7 @@ jobs:
             if [ "${{ matrix.optional }}" == "true" ]; then
               echo "::warning::Optional matrix job failed."
               echo "optional_fail=true" >> "${GITHUB_OUTPUT}"
-              echo "### Optional matrix job Py:${{ matrix.python-version }} - ${{ matrix.os }} failed" >> "${GITHUB_STEP_SUMMARY}"
-              echo " - tox-prefix: ${{ matrix.tox-prefix }}" >> "${GITHUB_STEP_SUMMARY}"
-              echo " - exit status: ${status}" >> "${GITHUB_STEP_SUMMARY}"
+              echo "optional_fail_status=${status}" >> "${GITHUB_OUTPUT}"
             fi;
             exit ${status}
           fi;
@@ -267,7 +265,10 @@ jobs:
         uses: thollander/actions-comment-pull-request@v3
         with:
           comment-tag: "${{ matrix.python-version }}-${{ matrix.os }}-optional-notice"
-          file-path: "${GITHUB_STEP_SUMMARY}"
+          message: |
+            ### Optional matrix job Py:${{ matrix.python-version }} - ${{ matrix.os }} failed
+             - tox prefix: ${{ matrix.tox-prefix }}
+             - exit status: ${{ steps.test.outputs.optional_fail_status }}
 
       # Use the latest supported Python version for combining coverage to
       # prevent parsing errors in older versions when looking at modern code.

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -239,7 +239,11 @@ jobs:
           if ! tox run -e ${TOX_ENV}; then
             status=$?
             if [ "${{ matrix.optional }}" == "true" ]; then
-              echo "::warning::Optional matrix job failed.";
+              echo "::warning::Optional matrix job failed."
+              echo "optional_fail=true" >> "${GITHUB_OUTPUT}"
+              echo "### Optional matrix job Py:${{ matrix.python-version }} - ${{ matrix.os }} failed" >> "${GITHUB_STEP_SUMMARY}"
+              echo " - tox-prefix: ${{ matrix.tox-prefix }}"
+              echo " - exit status: "${status}" >> "${GITHUB_STEP_SUMMARY}"
             fi;
             exit ${status}
           fi;

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -235,6 +235,7 @@ jobs:
           tox run -e lint --notest
 
       - name: Run unit tests
+        id: test
         run: |
           if ! tox run -e ${TOX_ENV}; then
             status=$?
@@ -255,7 +256,7 @@ jobs:
           IMS_TEST_MYSQL_PASSWORD: ims
 
       - name: Upload Trial log artifact
-        if: ${{ failure() }}
+        if: ${{ failure() || steps.test.outputs.optional_fail == "true" }}
         uses: actions/upload-artifact@v4
         with:
           name: trial

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -253,21 +253,26 @@ jobs:
           IMS_TEST_MYSQL_PASSWORD: ims
 
       - name: Upload Trial log artifact
-        if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
           name: trial
           path: .tox/${TOX_ENV}/log/trial.log
 
-      - name: Add comment if optional job failed
-        if: ${{ failure() && steps.test.outputs.optional_fail == 'true' }}
+      - name: Clear prior optional job failed comment, if any
         uses: thollander/actions-comment-pull-request@v3
         with:
           comment-tag: "${{ matrix.python-version }}-${{ matrix.os }}-optional-notice"
-          message: |
-            ### Optional matrix job Py:${{ matrix.python-version }} - ${{ matrix.os }} failed!
-             - tox prefix: ${{ matrix.tox-prefix }}
-             - exit status: ${{ steps.test.outputs.optional_fail_status }}
+          mode: delete
+
+      # - name: Add comment if optional job failed
+      #   if: ${{ failure() && steps.test.outputs.optional_fail == 'true' }}
+      #   uses: thollander/actions-comment-pull-request@v3
+      #   with:
+      #     comment-tag: "${{ matrix.python-version }}-${{ matrix.os }}-optional-notice"
+      #     message: |
+      #       ### Optional matrix job Py:${{ matrix.python-version }} - ${{ matrix.os }} failed!
+      #        - tox prefix: ${{ matrix.tox-prefix }}
+      #        - exit status: ${{ steps.test.outputs.optional_fail_status }}
 
       # Use the latest supported Python version for combining coverage to
       # prevent parsing errors in older versions when looking at modern code.

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -253,14 +253,14 @@ jobs:
           IMS_TEST_MYSQL_PASSWORD: ims
 
       - name: Upload Trial log artifact
-        if: ${{ failure() || steps.test.outputs.optional_fail == 'true' }}
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
           name: trial
           path: .tox/${TOX_ENV}/log/trial.log
 
       - name: Add comment if optional job failed
-        if: ${{ steps.test.outputs.optional_fail == 'true' }}
+        if: ${{ failure() && steps.test.outputs.optional_fail == 'true' }}
         uses: thollander/actions-comment-pull-request@v3
         with:
           comment-tag: "${{ matrix.python-version }}-${{ matrix.os }}-optional-notice"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -239,7 +239,7 @@ jobs:
         run: |
           status=0
           tox run -e "${TOX_ENV}" || status=$?
-          if [ ! ${status} && "${{ matrix.optional }}" == "true" ]; then
+          if [ ${status} -ne 0 ] && [ "${{ matrix.optional }}" == "true" ]; then
             echo "::warning::Optional matrix job failed."
             echo "optional_fail=true" >> "${GITHUB_OUTPUT}"
             echo "optional_fail_status=${status}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
GHA workflows fail when a job fails.

We use `continue-on-error` to prevent halting the workflow, and that is good enough for validation prior to merge, it leaves us with a visually annoying red X where we want to see a green checkmark.

What we want is support in GHA for the workflow to ignore specific job failures, but that doesn't exist. (A very popular but unimplemented [feature request](https://github.com/actions/runner/issues/2347) already exists for this.)

This PR is an attempt at a work-around.