### PR TITLE
feat: use just two SQL calls to back the incidents API

### DIFF
--- a/src/ims/store/mysql/_queries.py
+++ b/src/ims/store/mysql/_queries.py
@@ -213,6 +213,67 @@ queries = Queries(
         select max(NUMBER) from INCIDENT where EVENT = ({query_eventID})
         """,
     ),
+    incidents=Query(
+        "look up incidents for event",
+        f"""
+        select
+            i.NUMBER,
+            i.CREATED,
+            i.PRIORITY,
+            i.STATE,
+            i.SUMMARY,
+            i.LOCATION_NAME,
+            i.LOCATION_CONCENTRIC,
+            i.LOCATION_RADIAL_HOUR,
+            i.LOCATION_RADIAL_MINUTE,
+            i.LOCATION_DESCRIPTION,
+            i.EVENT,
+            (
+                select json_arrayagg(it.NAME)
+                from INCIDENT__INCIDENT_TYPE iit
+                join INCIDENT_TYPE it
+                    on i.EVENT = iit.EVENT
+                    and i.NUMBER = iit.INCIDENT_NUMBER
+                    and iit.INCIDENT_TYPE = it.ID
+            ) as INCIDENT_TYPES,
+            (
+                select json_arrayagg(irep.NUMBER)
+                from INCIDENT_REPORT irep
+                where i.EVENT = irep.EVENT
+                    and i.NUMBER = irep.INCIDENT_NUMBER
+            ) as INCIDENT_REPORT_NUMBERS,
+            (
+                select json_arrayagg(ir.RANGER_HANDLE)
+                from INCIDENT__RANGER ir
+                where i.EVENT = ir.EVENT
+                    and i.NUMBER = ir.INCIDENT_NUMBER
+            ) as RANGER_HANDLES
+        from
+            INCIDENT i
+        where
+            i.EVENT = ({query_eventID})
+        group by
+            i.NUMBER
+        """,
+    ),
+    incidents_reportEntries=Query(
+        "look up report entries for all incidents in an event",
+        f"""
+        select
+            ire.INCIDENT_NUMBER,
+            re.AUTHOR,
+            re.TEXT,
+            re.CREATED,
+            re.GENERATED
+        from
+            INCIDENT__REPORT_ENTRY ire
+            join REPORT_ENTRY re
+                on re.ID = ire.REPORT_ENTRY
+        where
+            ire.EVENT = ({query_eventID})
+        ;
+        """,
+    ),
     attachRangeHandleToIncident=Query(
         "add Ranger to incident",
         f"""


### PR DESCRIPTION
Currently a call to listIncidents (the API that backs the incidents page) results in over 5*n sequential DB lookups, where n is the number of incidents in the relevant event. Given that we build to over 1000 incidents per event, that starts to be quite a lot of queries for each incidents page load. My suspicion is that it'd be much faster to issue just a few big queries instead, and that's what this change does.

On staging, before this change, a listIncidents for 2023 takes about 10 seconds and issues over 6000 DB selects. I'm hopeful that this change will bring that duration down significantly. https://ranger-ims-staging.burningman.org/ims/api/events/2023/incidents/

I've confirmed locally for MySQL and for SQLite that this change doesn't alter the API result for my bunch of test data. The DataStoreIncidentTests pass on this change too, so that's pretty cool.

https://github.com/burningmantech/ranger-ims-server/issues/1324