### PR TITLE
allow deploy workflow to connect to api.github.com

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -429,6 +429,7 @@ jobs:
             github.com:443
             pypi.org:443
             raw.githubusercontent.com:443
+            api.github.com:443
 
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,7 @@ jobs:
             pypi.org:443
             raw.githubusercontent.com:443
             sts.us-west-2.amazonaws.com:443
+            api.github.com:443
 
       - name: Check user
         if: ${{ ! contains('["wsanchez", "mikeburg", "plapsley"]', github.actor) }}


### PR DESCRIPTION
This appears to be necessary for the Python 3.13 package fetch