### PR TITLE
support Unicode in IMS, by switching to utf8 encodings in MariaDB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
       - server
 
   database:
+    # this should match the value in:
+    # https://github.com/burningmantech/ranger-ims-server/blob/master/src/ims/store/mysql/test/service.py
     image: "${IMS_DB_IMAGE:-mariadb:10.5.24}"
     container_name: ranger_ims_database
     environment:

--- a/src/ims/store/mysql/_store.py
+++ b/src/ims/store/mysql/_store.py
@@ -100,7 +100,7 @@ class DataStore(DatabaseStore):
 
     _log: ClassVar[Logger] = Logger()
 
-    schemaVersion: ClassVar[int] = 6
+    schemaVersion: ClassVar[int] = 7
     schemaBasePath: ClassVar[Path] = Path(__file__).parent / "schema"
     sqlFileExtension: ClassVar[str] = "mysql"
 

--- a/src/ims/store/mysql/schema/7-from-6.mysql
+++ b/src/ims/store/mysql/schema/7-from-6.mysql
@@ -1,0 +1,23 @@
+/* Switch all tables to utf8mb4 character set (from latin1) to support Unicode text in IMS */
+
+/* This is the only constraint that needs to be dropped and re-added, since it includes varchars as part of the key. */
+alter table `INCIDENT` drop constraint `INCIDENT_ibfk_2`;
+
+alter table `CONCENTRIC_STREET` convert to character set utf8mb4 collate utf8mb4_unicode_ci;
+alter table `EVENT` convert to character set utf8mb4 collate utf8mb4_unicode_ci;
+alter table `EVENT_ACCESS` convert to character set utf8mb4 collate utf8mb4_unicode_ci;
+alter table `INCIDENT` convert to character set utf8mb4 collate utf8mb4_unicode_ci;
+alter table `INCIDENT_REPORT` convert to character set utf8mb4 collate utf8mb4_unicode_ci;
+alter table `INCIDENT_REPORT__REPORT_ENTRY` convert to character set utf8mb4 collate utf8mb4_unicode_ci;
+alter table `INCIDENT_TYPE` convert to character set utf8mb4 collate utf8mb4_unicode_ci;
+alter table `INCIDENT__INCIDENT_TYPE` convert to character set utf8mb4 collate utf8mb4_unicode_ci;
+alter table `INCIDENT__RANGER` convert to character set utf8mb4 collate utf8mb4_unicode_ci;
+alter table `INCIDENT__REPORT_ENTRY` convert to character set utf8mb4 collate utf8mb4_unicode_ci;
+alter table `REPORT_ENTRY` convert to character set utf8mb4 collate utf8mb4_unicode_ci;
+alter table `SCHEMA_INFO` convert to character set utf8mb4 collate utf8mb4_unicode_ci;
+
+alter table `INCIDENT` add constraint `INCIDENT_ibfk_2` foreign key (`EVENT`, `LOCATION_CONCENTRIC`) references `CONCENTRIC_STREET` (`EVENT`, `ID`);
+
+/* Update schema version */
+
+update `SCHEMA_INFO` set VERSION = 7;

--- a/src/ims/store/mysql/schema/7.mysql
+++ b/src/ims/store/mysql/schema/7.mysql
@@ -1,8 +1,8 @@
 create table SCHEMA_INFO (
     VERSION smallint not null
-);
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
-insert into SCHEMA_INFO (VERSION) values (6);
+insert into SCHEMA_INFO (VERSION) values (7);
 
 
 create table EVENT (
@@ -11,7 +11,7 @@ create table EVENT (
 
     primary key (ID),
     unique key (NAME)
-);
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 
 create table CONCENTRIC_STREET (
@@ -20,7 +20,7 @@ create table CONCENTRIC_STREET (
     NAME  varchar(128) not null,
 
     primary key (EVENT, ID)
-);
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 
 create table INCIDENT_TYPE (
@@ -30,7 +30,7 @@ create table INCIDENT_TYPE (
 
     primary key (ID),
     unique key (NAME)
-);
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 insert into INCIDENT_TYPE (NAME, HIDDEN) values ('Admin', 0);
 insert into INCIDENT_TYPE (NAME, HIDDEN) values ('Junk' , 0);
@@ -48,7 +48,7 @@ create table REPORT_ENTRY (
     -- Primary key is DMS Person ID.
 
     primary key (ID)
-);
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 
 create table INCIDENT (
@@ -75,7 +75,7 @@ create table INCIDENT (
     references CONCENTRIC_STREET(EVENT, ID),
 
     primary key (EVENT, NUMBER)
-);
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 
 create table INCIDENT__RANGER (
@@ -90,7 +90,7 @@ create table INCIDENT__RANGER (
     -- Primary key is DMS Person ID.
 
     primary key (EVENT, INCIDENT_NUMBER, RANGER_HANDLE)
-);
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 
 create table INCIDENT__INCIDENT_TYPE (
@@ -103,7 +103,7 @@ create table INCIDENT__INCIDENT_TYPE (
     foreign key (INCIDENT_TYPE) references INCIDENT_TYPE(ID),
 
     primary key (EVENT, INCIDENT_NUMBER, INCIDENT_TYPE)
-);
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 
 create table INCIDENT__REPORT_ENTRY (
@@ -116,7 +116,7 @@ create table INCIDENT__REPORT_ENTRY (
     foreign key (REPORT_ENTRY) references REPORT_ENTRY(ID),
 
     primary key (EVENT, INCIDENT_NUMBER, REPORT_ENTRY)
-);
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 
 create table EVENT_ACCESS (
@@ -128,7 +128,7 @@ create table EVENT_ACCESS (
     foreign key (EVENT) references EVENT(ID),
 
     primary key (EVENT, EXPRESSION)
-);
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 
 create table INCIDENT_REPORT (
@@ -143,7 +143,7 @@ create table INCIDENT_REPORT (
     foreign key (EVENT, INCIDENT_NUMBER) references INCIDENT(EVENT, NUMBER),
 
     primary key (EVENT, NUMBER)
-);
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 
 create table INCIDENT_REPORT__REPORT_ENTRY (
@@ -157,4 +157,4 @@ create table INCIDENT_REPORT__REPORT_ENTRY (
     foreign key (REPORT_ENTRY) references REPORT_ENTRY(ID),
 
     primary key (EVENT, INCIDENT_REPORT_NUMBER, REPORT_ENTRY)
-);
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/ims/store/mysql/test/test_store_core.py
+++ b/src/ims/store/mysql/test/test_store_core.py
@@ -146,7 +146,7 @@ class DataStoreCoreTests(AsynchronousTestCase):
         self.assertEqual(
             dedent(
                 """
-                Version: 6
+                Version: 7
                 CONCENTRIC_STREET:
                   1: EVENT(int) not null
                   2: ID(varchar(16)) not null

--- a/src/ims/store/test/incident.py
+++ b/src/ims/store/test/incident.py
@@ -86,7 +86,7 @@ anIncident2 = Incident(
     created=DateTime.now(TimeZone.utc) + TimeDelta(seconds=3),
     state=IncidentState.new,
     priority=IncidentPriority.normal,
-    summary="Another thing happened",
+    summary="Another thing happened 🙂",
     location=Location(name="Here", address=None),
     rangerHandles=(),
     incidentTypes=(),


### PR DESCRIPTION
I've verified this locally on my prod-like databases. It seems to just work!
I make the change, seemingly nothing looks different in the web client,
and suddenly I'm able to start saving non-latin1 characters as part of
incident text fields.

Our SQLite setup already support Unicode, so there's nothing to do over there.

https://github.com/burningmantech/ranger-ims-server/issues/1353

This also fixes the database version used for local MariaDB tests.
They were failing for me, since we're using features not supported
by that old version of MySQL. We need to watch for different log
text to indicate that a MariaDB instance is ready, too.