### PR TITLE
require event_id parameter on personnel API calls

### DIFF
--- a/src/ims/application/_api.py
+++ b/src/ims/application/_api.py
@@ -225,8 +225,9 @@ class APIApplication:
         """
         Personnel endpoint.
         """
+        eventId = queryValue(request, "event_id")
         await self.config.authProvider.authorizeRequest(
-            request, None, Authorization.readPersonnel
+            request, eventId, Authorization.readPersonnel
         )
 
         stream, etag = await self.personnelData()

--- a/src/ims/auth/_provider.py
+++ b/src/ims/auth/_provider.py
@@ -397,8 +397,6 @@ class AuthProvider:
         authorizations = Authorization.none
 
         if user is not None:
-            authorizations |= Authorization.readPersonnel
-
             for shortName in user.shortNames:
                 if shortName in self.adminUsers:
                     authorizations |= Authorization.imsAdmin
@@ -410,12 +408,14 @@ class AuthProvider:
                 authorizations |= Authorization.writeIncidents
                 authorizations |= Authorization.readIncidents
                 authorizations |= Authorization.writeIncidentReports
+                authorizations |= Authorization.readPersonnel
 
             else:
                 if self._matchACL(
                     user, frozenset(await self.store.readers(eventID))
                 ):
                     authorizations |= Authorization.readIncidents
+                    authorizations |= Authorization.readPersonnel
 
                 if self._matchACL(
                     user,

--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -244,7 +244,7 @@ function loadPersonnel(success) {
         setErrorMessage(message);
     }
 
-    jsonRequest(url_personnel, null, ok, fail);
+    jsonRequest(urlReplace(url_personnel + "?event_id=<event_id>"), null, ok, fail);
 }
 
 


### PR DESCRIPTION
The motivation is really just to lock down this endpoint. The only Rangers who need it are those with readIncident or writeIncident permissions. That's already a small subset of Rangers, even during event week. For the rest of the year, when almost no one has access to read or write incidents, the privacy benefit here becomes better still.