### PR TITLE
don't show location on incidents page if it'd be "(?:?@)"

### DIFF
--- a/src/ims/element/static/ims.js
+++ b/src/ims/element/static/ims.js
@@ -543,13 +543,15 @@ function shortDescribeLocation(location) {
             }
             break;
         case "garett":
-            locationBits.push(" (");
-            locationBits.push(padTwo(location.radial_hour));
-            locationBits.push(":");
-            locationBits.push(padTwo(location.radial_minute));
-            locationBits.push("@");
-            locationBits.push(concentricStreetFromID(location.concentric));
-            locationBits.push(")");
+            if (location.radial_hour || location.radial_minute || location.concentric) {
+                locationBits.push(" (");
+                locationBits.push(padTwo(location.radial_hour));
+                locationBits.push(":");
+                locationBits.push(padTwo(location.radial_minute));
+                locationBits.push("@");
+                locationBits.push(concentricStreetFromID(location.concentric));
+                locationBits.push(")");
+            }
             break;
         default:
             locationBits.push(


### PR DESCRIPTION
The Rod Garett-style addresses are often left empty in practice, when they're irrelevant (e.g. Gerlach, or Black Rock Station, or unknown). It's kind of an eyesore to see those displayed as "(?:?@)" in the incidents table. Before and after example pics are below.

<img width="253" alt="image" src="https://github.com/user-attachments/assets/716d0994-70f7-4618-9166-b737cd8878fe">

<img width="181" alt="image" src="https://github.com/user-attachments/assets/db4958a1-2a6f-4b07-bb8d-f43d2bf3b7d3">
