### PR TITLE
fix "Add" formatting, use datalist and text for incident types

### DIFF
--- a/src/ims/element/incident/incident_template/template.xhtml
+++ b/src/ims/element/incident/incident_template/template.xhtml
@@ -75,7 +75,7 @@
             </span>
           </li>
         </ul>
-        <div>
+        <div class="flex-input-container">
           <label class="control-label">Add:</label>
           <input
             type="text"
@@ -100,15 +100,18 @@
             </span>
           </li>
         </ul>
-        <div>
+        <div class="flex-input-container">
           <label class="control-label">Add:</label>
-          <select
+          <input
+            type="text"
             id="incident_type_add"
+            list="incident_types"
             class="form-control input-sm auto-width"
             onchange="addIncidentType()"
-          >
+          />
+          <datalist id="incident_types">
             <option value="" />
-          </select>
+          </datalist>
         </div>
       </div>
     </div>

--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -637,19 +637,18 @@ function drawIncidentTypes() {
 
 
 function drawIncidentTypesToAdd() {
-    var select = $("#incident_type_add");
+    var datalist = $("#incident_types");
 
-    select.empty();
-    select.append($("<option />"));
+    datalist.empty();
+    datalist.append($("<option />"));
 
     for (var i in incidentTypes) {
         var incidentType = incidentTypes[i];
 
         var option = $("<option />");
         option.val(incidentType);
-        option.text(incidentType);
 
-        select.append(option);
+        datalist.append(option);
     }
 }
 
@@ -1065,21 +1064,27 @@ function addRanger() {
 function addIncidentType() {
     var select = $("#incident_type_add");
     var incidentType = $(select).val();
-    var incidentTypes = incident.incident_types
+    var currentIncidentTypes = incident.incident_types
 
-    if (incidentTypes == undefined) {
-        incidentTypes = [];
+    if (currentIncidentTypes == undefined) {
+        currentIncidentTypes = [];
     } else {
-        incidentTypes = incidentTypes.slice();  // copy
+        currentIncidentTypes = currentIncidentTypes.slice();  // copy
     }
 
-    if (incidentTypes.indexOf(incidentType) != -1) {
+    if (currentIncidentTypes.indexOf(incidentType) != -1) {
         // Already in the list, so… move along.
         select.val("");
         return;
     }
 
-    incidentTypes.push(incidentType);
+    if (incidentTypes.indexOf(incidentType) == -1) {
+        // Not a valid incident type
+        select.val("");
+        return;
+    }
+
+    currentIncidentTypes.push(incidentType);
 
     function ok() {
         select.val("");
@@ -1091,7 +1096,7 @@ function addIncidentType() {
         select.val("");
     }
 
-    sendEdits({"incident_types": incidentTypes}, ok, fail);
+    sendEdits({"incident_types": currentIncidentTypes}, ok, fail);
 }
 
 


### PR DESCRIPTION
The "Add" textboxes were both artificially narrow. We might as well use the flex-input-container class, as used elsewhere on the page.

This also makes incident types a searchable text field, as I recently made the case for the "Add Rangers" dropdown. As with the Rangers list, this only permits values from the incident types list.

**Before: (narrow "add" boxes, select field for incident types)**

<img width="820" alt="image" src="https://github.com/user-attachments/assets/f42c2efb-5dfb-48e3-b4ff-a6e47ac90b35">

**After: (auto-sized "add" boxes, text field with datalist for incident types)**

<img width="816" alt="image" src="https://github.com/user-attachments/assets/2bc01b64-e7e8-4c8f-b664-c0ebd1ea8c8d">
