### PR TITLE
stop shuffling ranger_handles and incident_types

### DIFF
--- a/src/ims/model/_convert.py
+++ b/src/ims/model/_convert.py
@@ -35,6 +35,11 @@ def freezeStrings(strings: Iterable[str]) -> frozenset[str]:
     return frozenset(strings)
 
 
+def dedupeStrings(strings: Iterable[str]) -> tuple[str, ...]:
+    deduped = {s: None for s in strings}
+    return tuple(s for s in deduped)
+
+
 def normalizeDateTime(dateTime: DateTime) -> DateTime:
     """
     Shave some precision off of DateTimes, since it may not round-trip well

--- a/src/ims/model/_incident.py
+++ b/src/ims/model/_incident.py
@@ -27,7 +27,7 @@ from attrs import field, frozen
 
 from ims.ext.attr import sorted_tuple
 
-from ._convert import freezeIntegers, freezeStrings, normalizeDateTime
+from ._convert import dedupeStrings, freezeIntegers, normalizeDateTime
 from ._entry import ReportEntry
 from ._location import Location
 from ._priority import IncidentPriority
@@ -57,8 +57,8 @@ class Incident(ReplaceMixIn):
     priority: IncidentPriority
     summary: str | None
     location: Location
-    rangerHandles: frozenset[str] = field(converter=freezeStrings)
-    incidentTypes: frozenset[str] = field(converter=freezeStrings)
+    rangerHandles: tuple[str, ...] = field(converter=dedupeStrings)
+    incidentTypes: tuple[str, ...] = field(converter=dedupeStrings)
     reportEntries: Sequence[ReportEntry] = field(
         converter=sortAndFreezeReportEntries
     )

--- a/src/ims/model/_ranger.py
+++ b/src/ims/model/_ranger.py
@@ -25,7 +25,7 @@ from attrs import field, frozen
 
 from ims.ext.enum import Names, auto, unique
 
-from ._convert import freezeStrings
+from ._convert import dedupeStrings
 from ._replace import ReplaceMixIn
 
 
@@ -73,8 +73,8 @@ class Ranger(ReplaceMixIn):
     handle: str
     name: str
     status: RangerStatus
-    email: frozenset[str] = field(
-        converter=freezeStrings, default=frozenset[str]()
+    email: tuple[str, ...] = field(
+        converter=dedupeStrings, default=tuple[str, ...]()
     )
     enabled: bool
     directoryID: str | None


### PR DESCRIPTION
Currently those fields under an incident get randomly sorted in the API response, since a frozenset is unordered. This surfaces on the incidents page, where ranger handles and incident types both show up in a random order. That's kind of weird.

This is a pretty simple fix for that, which makes the API response consistent.

I've looked through the Git history a fair bit to see why frozensets were used in the first place. I'm fairly confident it was just because we needed an immutable, hashable collection with duplicates removed. This new way achieves those same ends too, but it also maintains ordering.
https://github.com/search?q=repo%3Aburningmantech%2Franger-ims-server+frozenset&type=commits

https://github.com/burningmantech/ranger-ims-server/issues/1348
https://github.com/burningmantech/ranger-ims-server/issues/373