### PR TITLE
do bulk lookups when fetching all incident reports for event

### DIFF
--- a/src/ims/store/mysql/_queries.py
+++ b/src/ims/store/mysql/_queries.py
@@ -421,6 +421,38 @@ queries = Queries(
         select max(NUMBER) from INCIDENT_REPORT
         """,
     ),
+    incidentReports=Query(
+        "look up all incident reports for an event",
+        f"""
+        select
+            NUMBER,
+            CREATED,
+            SUMMARY,
+            INCIDENT_NUMBER
+        from
+            INCIDENT_REPORT
+        where
+            EVENT = ({query_eventID})
+        """,
+    ),
+    incidentReports_reportEntries=Query(
+        "look up all incident report report entries for an event",
+        f"""
+        select
+            irre.INCIDENT_REPORT_NUMBER,
+            re.AUTHOR,
+            re.CREATED,
+            re.GENERATED,
+            re.ID,
+            re.TEXT
+        from
+            INCIDENT_REPORT__REPORT_ENTRY irre
+            join REPORT_ENTRY re
+                on irre.REPORT_ENTRY = re.ID
+        where
+            irre.EVENT = ({query_eventID})
+        """,
+    ),
     createIncidentReport=Query(
         "create incident report",
         f"""

--- a/src/ims/store/sqlite/_queries.py
+++ b/src/ims/store/sqlite/_queries.py
@@ -413,6 +413,38 @@ queries = Queries(
         select max(NUMBER) from INCIDENT_REPORT
         """,
     ),
+    incidentReports=Query(
+        "look up all incident reports for an event",
+        f"""
+        select
+            NUMBER,
+            CREATED,
+            SUMMARY,
+            INCIDENT_NUMBER
+        from
+            INCIDENT_REPORT
+        where
+            EVENT = ({query_eventID})
+        """,
+    ),
+    incidentReports_reportEntries=Query(
+        "look up all incident report report entries for an event",
+        f"""
+        select
+            irre.INCIDENT_REPORT_NUMBER,
+            re.AUTHOR,
+            re.CREATED,
+            re.GENERATED,
+            re.ID,
+            re.TEXT
+        from
+            INCIDENT_REPORT__REPORT_ENTRY irre
+            join REPORT_ENTRY re
+                on irre.REPORT_ENTRY = re.ID
+        where
+            irre.EVENT = ({query_eventID})
+        """,
+    ),
     createIncidentReport=Query(
         "create incident report",
         f"""


### PR DESCRIPTION
Currently this sort of fetch does up to thousands of queries each time, which seems inefficient. I had pretty good success moving the fetchIncidents call over to bulk queries, and I'm seeing at least a 2x speedup locally with this change as well.

Related:
https://github.com/burningmantech/ranger-ims-server/issues/1324