### PR TITLE
limit "add attached incident report" dropdown width

### DIFF
--- a/src/ims/element/incident/incident_template/template.xhtml
+++ b/src/ims/element/incident/incident_template/template.xhtml
@@ -195,11 +195,11 @@
             </span>
           </li>
         </ul>
-        <div id="attached_incident_report_add_container">
+        <div id="attached_incident_report_add_container" class="flex-input-container">
           <label class="control-label">Add:</label>
           <select
             id="attached_incident_report_add"
-            class="form-control input-sm auto-width"
+            class="form-control input-sm"
             onchange="attachIncidentReport()"
           >
             <option value="" />


### PR DESCRIPTION
See this: https://github.com/burningmantech/ranger-ims-server/issues/1372

This PR stops the select box from overflowing the screen