### PR TITLE
fix "controlClear" function

### DIFF
--- a/src/ims/element/static/ims.js
+++ b/src/ims/element/static/ims.js
@@ -234,7 +234,10 @@ function controlHasError(element) {
 function controlHasSuccess(element, clearTimeout) {
     element.parent().addClass("has-success");
     if (clearTimeout != undefined) {
-        element.delay("1000").queue(function() {controlClear(element)});
+        element.delay("1000").queue(function(next) {
+            controlClear(element);
+            next();
+        });
     }
 }
 


### PR DESCRIPTION
A jQuery queue function needs to dequeue itself in order to let subsequent functions run. As things were, for example, if you modify the summary field, this function would correctly clear the formatting after 1 second, but then on a second modification, this function would not run and the formatting would not unset.