### PR TITLE
rename "incident reports" to "field reports" in UI

### DIFF
--- a/src/ims/config/_urls.py
+++ b/src/ims/config/_urls.py
@@ -131,9 +131,9 @@ class URLs:
     viewIncidentTemplate: ClassVar[URL] = app.child("incident.html")
     viewIncidentJS: ClassVar[URL] = static.child("incident.js")
 
-    viewIncidentReports: ClassVar[URL] = viewEvent.child(
-        "incident_reports"
-    ).child("")
+    viewIncidentReports: ClassVar[URL] = viewEvent.child("field_reports").child(
+        ""
+    )
     viewIncidentReportsTemplate: ClassVar[URL] = app.child(
         "incident_reports.html"
     )

--- a/src/ims/element/incident/incident_template/template.xhtml
+++ b/src/ims/element/incident/incident_template/template.xhtml
@@ -10,7 +10,7 @@
   <div class="row">
       <div class="col-sm-4 text-left">
         <div class="form-group">
-          <label class="control-label">Incident #:</label>
+          <label class="control-label">IMS #:</label>
           <span id="incident_number" class="form-control-static" />
         </div>
       </div>
@@ -179,11 +179,11 @@
     </div>
   </div>
 
-  <!-- Attached incident reports -->
+  <!-- Attached field reports -->
 
   <div class="row">
     <div class="col-sm-12">
-      <label class="control-label">Attached Incident Reports</label>
+      <label class="control-label">Attached Field Reports</label>
       <div class="well well-sm">
         <ul id="attached_incident_reports" class="list-group list-group-small">
           <li class="list-group-item">

--- a/src/ims/element/incident/incidents_template/template.xhtml
+++ b/src/ims/element/incident/incidents_template/template.xhtml
@@ -6,8 +6,8 @@
   </div>
 
   <p class="no-print">
-    <a href="../incident_reports/">
-      <span class="glyphicon glyphicon-arrow-right" /> Incident Reports
+    <a href="../field_reports/">
+      <span class="glyphicon glyphicon-arrow-right" /> Field Reports
     </a>
   </p>
 

--- a/src/ims/element/incident/report_template/_report_template.py
+++ b/src/ims/element/incident/report_template/_report_template.py
@@ -26,7 +26,7 @@ from ...page import Page
 __all__ = ()
 
 
-title = "Incident Report Details"
+title = "Field Report Details"
 
 
 @mutable(kw_only=True)

--- a/src/ims/element/incident/report_template/template.xhtml
+++ b/src/ims/element/incident/report_template/template.xhtml
@@ -8,7 +8,7 @@
   <div class="row">
       <div class="col-sm-4 text-left">
         <div class="form-group">
-          <label class="control-label">Incident Report #:</label>
+          <label class="control-label">FR #:</label>
           <span id="incident_report_number" class="form-control-static" />
         </div>
       </div>
@@ -79,11 +79,11 @@
     </div>
   </div>
 
-  <!-- Incident report details -->
+  <!-- Field report details -->
 
   <div class="row">
     <div class="col-sm-12">
-      <label>Incident Report Details</label>
+      <label>Field Report Details</label>
       <div id="incident_report_well" class="well well-sm">
         <div class="panel panel-default">
           <div class="panel-body">

--- a/src/ims/element/incident/reports_template/_reports_template.py
+++ b/src/ims/element/incident/reports_template/_reports_template.py
@@ -26,7 +26,7 @@ from ...page import Page
 __all__ = ()
 
 
-title = "Incident Reports"
+title = "Field Reports"
 
 
 @mutable(kw_only=True)

--- a/src/ims/element/static/ims.js
+++ b/src/ims/element/static/ims.js
@@ -430,7 +430,7 @@ function summarizeIncident(incident) {
 }
 
 
-// Return a summary for a given incident report.
+// Return a summary for a given field report.
 function summarizeIncidentReport(report) {
     return summarizeIncident(report);
 }
@@ -449,7 +449,7 @@ function incidentAuthor(incident) {
 }
 
 
-// Get author for incident report
+// Get author for field report
 function incidentReportAuthor(report) {
     return incidentAuthor(report);
 }
@@ -461,20 +461,20 @@ function incidentAsString(incident) {
         document.title = "New Incident";
     } else {
         return (
-            incident.event + " incident #" + incident.number + ": " +
+            incident.event + " IMS #" + incident.number + ": " +
             summarizeIncident(incident)
         );
     }
 }
 
 
-// Render incident report as a string
+// Render field report as a string
 function incidentReportAsString(report) {
     if (report.number == null) {
-        document.title = "New Incident Report";
+        document.title = "New Field Report";
     } else {
         return (
-            "Report #" + report.number +
+            "FR #" + report.number +
             " (" + incidentReportAuthor(report) + "): " +
             summarizeIncidentReport(report)
         );
@@ -507,7 +507,7 @@ function reportTextFromIncident(incident) {
         }
     }
 
-    // Incidents page loads all incident reports for the event
+    // Incidents page loads all field reports for the event
     if (typeof eventIncidentReports !== "undefined") {
         for (var i in incident.incident_reports) {
             var reportNumber = incident.incident_reports[i];
@@ -707,7 +707,7 @@ function reportEntryElement(entry) {
         metaDataContainer.append(" ");
 
         var link = $("<a />");
-        link.text("incident report #" + entry.merged);
+        link.text("field report #" + entry.merged);
         link.attr("href", urlReplace(url_viewIncidentReports) + entry.merged)
 
         var reportNumberContainer = $("<span />");

--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -324,7 +324,7 @@ function localLoadIncidentTypes() {
 
 
 //
-// Load unattached incident reports
+// Load unattached field reports
 //
 
 var unattachedIncidentReports = null;
@@ -339,8 +339,8 @@ function loadUnattachedIncidentReports(success) {
         for (const d of data) {
             _unattachedIncidentReports.push(d);
         }
-        // apply an ascending sort based on the incident report number,
-        // being cautious about incident report number being null
+        // apply an ascending sort based on the field report number,
+        // being cautious about field report number being null
         _unattachedIncidentReports.sort(function (a, b) {
             return (a.number ?? -1) - (b.number ?? -1);
         })
@@ -356,7 +356,7 @@ function loadUnattachedIncidentReports(success) {
             // We're not allowed to look these up.
             unattachedIncidentReports = undefined;
         } else {
-            var message = "Failed to load unattached incident reports";
+            var message = "Failed to load unattached field reports";
             console.error(message + ": " + error);
             setErrorMessage(message);
         }
@@ -370,7 +370,7 @@ function loadUnattachedIncidentReports(success) {
 
 
 //
-// Load attached incident reports
+// Load attached field reports
 //
 
 var attachedIncidentReports = null;
@@ -389,7 +389,7 @@ function loadAttachedIncidentReports(success) {
     }
 
     function fail(error, status, xhr) {
-        var message = "Failed to load attached incident reports";
+        var message = "Failed to load attached field reports";
         console.error(message + ": " + error);
         setErrorMessage(message);
     }
@@ -806,7 +806,7 @@ function drawIncidentReportsToAttach() {
 
         select.append($("<optgroup label=\"Unattached to any incident\">"));
         for (const report of unattachedIncidentReports) {
-            // Skip incident reports that *are* attached to an incident
+            // Skip field reports that *are* attached to an incident
             if (report.incident != null) {
                 continue;
             }
@@ -820,7 +820,7 @@ function drawIncidentReportsToAttach() {
 
         select.append($("<optgroup label=\"Attached to another incident\">"));
         for (const report of unattachedIncidentReports) {
-            // Skip incident reports that *are not* attached to an incident
+            // Skip field reports that *are not* attached to an incident
             if (report.incident == null) {
                 continue;
             }
@@ -1139,7 +1139,7 @@ function detachIncidentReport(sender) {
         // FIXME
         // controlHasError(sender);
 
-        var message = "Failed to detach incident report";
+        var message = "Failed to detach field report";
         console.log(message + ": " + requestError);
         loadAndDisplayIncidentReports();
         setErrorMessage(message);
@@ -1169,7 +1169,7 @@ function attachIncidentReport() {
     }
 
     function fail(requestError, status, xhr) {
-        var message = "Failed to attach incident report";
+        var message = "Failed to attach field report";
         console.log(message + ": " + requestError);
         loadAndDisplayIncidentReports();
         setErrorMessage(message);

--- a/src/ims/element/static/incident_report.js
+++ b/src/ims/element/static/incident_report.js
@@ -110,7 +110,7 @@ function loadIncidentReport(success) {
 
     function fail(error, status, xhr) {
         disableEditing();
-        var message = "Failed to load incident report";
+        var message = "Failed to load field report";
         console.error(message + ": " + error);
         setErrorMessage(message);
     }
@@ -130,7 +130,7 @@ function loadIncidentReport(success) {
 function loadAndDisplayIncidentReport(success) {
     function loaded() {
         if (incidentReport == null) {
-            var message = "Incident report failed to load";
+            var message = "Field report failed to load";
             console.log(message);
             setErrorMessage(message);
             return;
@@ -167,7 +167,7 @@ function drawTitle() {
 
 
 //
-// Populate incident report number
+// Populate field report number
 //
 
 function drawNumber() {
@@ -180,7 +180,7 @@ function drawNumber() {
 
 
 //
-// Populate incident report summary
+// Populate field report summary
 //
 
 function drawSummary() {
@@ -207,7 +207,7 @@ function sendEdits(edits, success, error) {
     var url = urlReplace(url_incidentReports);
 
     if (number == null) {
-        // We're creating a new incident report.
+        // We're creating a new field report.
         var required = [];
         for (var i in required) {
             var key = required[i];
@@ -216,15 +216,15 @@ function sendEdits(edits, success, error) {
             }
         }
     } else {
-        // We're editing an existing incident report.
+        // We're editing an existing field report.
         edits.number = number;
         url += number;
     }
 
     function ok(data, status, xhr) {
         if (number == null) {
-            // We created a new incident report.
-            // We need to find out the create incident report number so that
+            // We created a new field report.
+            // We need to find out the created field report number so that
             // future edits don't keep creating new resources.
 
             newNumber = xhr.getResponseHeader("X-IMS-Incident-Report-Number")

--- a/src/ims/element/static/incident_reports.js
+++ b/src/ims/element/static/incident_reports.js
@@ -80,7 +80,7 @@ function initIncidentReportsTable() {
     const incidentReportChannel = new BroadcastChannel(incidentReportChannelName);
     incidentReportChannel.onmessage = function (e) {
         const number = e.data;
-        console.log("Got incident report update: " + number);
+        console.log("Got field report update: " + number);
         incidentReportsTable.ajax.reload(clearErrorMessage);
     }
 }

--- a/src/ims/element/static/incidents.js
+++ b/src/ims/element/static/incidents.js
@@ -60,11 +60,11 @@ function initIncidentsPage() {
 
 
 //
-// Load event incident reports
+// Load event field reports
 //
 // Note that nothing from these data is displayed in the incidents table.
 // We do this fetch in order to make incidents searchable by text in their
-// attached incident reports.
+// attached field reports.
 
 var eventIncidentReports = null;
 
@@ -85,14 +85,14 @@ function loadEventIncidentReports(success) {
     }
 
     function fail(error, status, xhr) {
-        var message = "Failed to load event incident reports";
+        var message = "Failed to load event field reports";
         console.error(message + ": " + error);
         setErrorMessage(message);
     }
 
     jsonRequest(urlReplace(url_incidentReports + "?exclude_system_entries=true"), null, ok, fail);
 
-    console.log("Loaded event incident reports");
+    console.log("Loaded event field reports");
     if (incidentsTable != null) {
         incidentsTable.ajax.reload(clearErrorMessage);
     }


### PR DESCRIPTION
also start using the initialism "IMS #" for incident number and "FR #" for field report number.

This is only a surface-level change, affecting pieces of IMS that are visible to users. There's a bunch more work to do sometime to rename everything else, from persistence to server code to APIs to JavaScript internals.

Relevant issue: https://github.com/burningmantech/ranger-ims-server/issues/371#issuecomment-2460716389