### PR TITLE
tweak login page's title and email label

### DIFF
--- a/src/ims/element/login/_login.py
+++ b/src/ims/element/login/_login.py
@@ -35,7 +35,7 @@ class LoginPage(Page):
     Login page.
     """
 
-    name: str = "Log In"
+    name: str = "Ranger Incident Management System"
     failed: bool = False
 
     @renderer

--- a/src/ims/element/login/template.xhtml
+++ b/src/ims/element/login/template.xhtml
@@ -11,11 +11,11 @@
         <button t:render="if_authz_failed" type="button" class="btn btn-block btn-danger">Authorization Failed for <code t:render="logged_in_user" /></button>
 
         <p>
-          Please provide your Ranger Secret Clubhouse credentials.
+          Please log in with your Ranger Secret Clubhouse credentials.
         </p>
 
         <div class="form-group">
-          <label for="username_input" class="col-sm-2 control-label" title="Log in with either your Clubhouse email address or your case-sensitive Ranger handle">Email (or handle):</label>
+          <label for="username_input" class="col-sm-2 control-label" title="Log in with either your Clubhouse email address or your case-sensitive Ranger handle">Email:</label>
           <div class="col-sm-3">
             <input id="username_input" type="text" name="username" inputmode="latin-name" class="form-control" autocomplete="username" />
           </div>


### PR DESCRIPTION
I went with "email (or handle)" for a while, but I'm now thinking we should just stay simple and ask for email only.

The title of the page was a bit weird before, just saying "Log In". I think it's better to say the name of the system instead, but I could be convinced otherwise.

Before:
<img width="393" alt="image" src="https://github.com/user-attachments/assets/a2a420b3-de36-4b74-b29b-8d3fab28c111">

After:
<img width="597" alt="image" src="https://github.com/user-attachments/assets/e262f5bc-7685-4378-96f2-9a48aadcc18c">
