### PR TITLE
make printing of incident pages look better

### DIFF
--- a/src/ims/element/incident/incident_template/template.xhtml
+++ b/src/ims/element/incident/incident_template/template.xhtml
@@ -75,7 +75,7 @@
             </span>
           </li>
         </ul>
-        <div class="flex-input-container">
+        <div class="flex-input-container no-print">
           <label class="control-label">Add:</label>
           <input
             type="text"
@@ -100,7 +100,7 @@
             </span>
           </li>
         </ul>
-        <div class="flex-input-container">
+        <div class="flex-input-container no-print">
           <label class="control-label">Add:</label>
           <input
             type="text"
@@ -195,7 +195,7 @@
             </span>
           </li>
         </ul>
-        <div id="attached_incident_report_add_container" class="flex-input-container">
+        <div id="attached_incident_report_add_container" class="flex-input-container no-print">
           <label class="control-label">Add:</label>
           <select
             id="attached_incident_report_add"
@@ -230,7 +230,7 @@
         </div>
         <textarea
           id="incident_report_add"
-          class="form-control input-sm"
+          class="form-control input-sm no-print"
           rows="3"
           placeholder="Additional report text..."
           autofocus=""
@@ -239,7 +239,7 @@
         <button
           id="report_entry_submit"
           type="submit"
-          class="btn btn-default btn-sm btn-block disabled"
+          class="btn btn-default btn-sm btn-block disabled no-print"
           onclick="submitReportEntry()"
         >
           Add Entry (Control ⏎)

--- a/src/ims/element/incident/incidents/template.xhtml
+++ b/src/ims/element/incident/incidents/template.xhtml
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" t:render="root">
   <head t:render="head" imports="dataTables,ims,viewIncidents">
-    <link type="text/css" rel="stylesheet" media="screen" t:render="url" url="dataTablesBootstrapCSS" />
+    <link type="text/css" rel="stylesheet" t:render="url" url="dataTablesBootstrapCSS" />
   </head>
 
   <body />

--- a/src/ims/element/incident/reports/template.xhtml
+++ b/src/ims/element/incident/reports/template.xhtml
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" t:render="root">
   <head t:render="head" imports="dataTables,ims,viewIncidentReports">
-    <link type="text/css" rel="stylesheet" media="screen" t:render="url" url="dataTablesBootstrapCSS" />
+    <link type="text/css" rel="stylesheet" t:render="url" url="dataTablesBootstrapCSS" />
   </head>
 
   <body />

--- a/src/ims/element/page/_page.py
+++ b/src/ims/element/page/_page.py
@@ -127,13 +127,11 @@ class Page(Element):
             tags.link(
                 type="text/css",
                 rel="stylesheet",
-                media="screen",
                 href=urls.bootstrapCSS.asText(),
             ),
             tags.link(
                 type="text/css",
                 rel="stylesheet",
-                media="screen",
                 href=urls.styleSheet.asText(),
             ),
             self.title(request, tags.title.clone()),

--- a/src/ims/element/page/footer/template.xhtml
+++ b/src/ims/element/page/footer/template.xhtml
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <footer xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" t:render="root">
-  <hr />
-  <p>IMS Software © Burning Man Project and its contributors. Data in IMS is confidential and proprietary.</p>
+  <div class="no-print">
+    <hr />
+    <p>IMS Software © Burning Man Project and its contributors. Data in IMS is confidential and proprietary.</p>
+  </div>
 </footer>

--- a/src/ims/element/static/style.css
+++ b/src/ims/element/static/style.css
@@ -57,6 +57,10 @@ a.navbar-brand>img {
   flex: 2;
 }
 
+.list-group {
+  margin-bottom: 8px;
+}
+
 .list-group-small > .list-group-item {
   padding: 6px 8px;
   font-size: 10pt;
@@ -146,4 +150,51 @@ a.navbar-brand>img {
 
 .hide-history .report_entry_system {
   display: none;
+}
+
+@media print {
+  .no-print {
+    display: none;
+  }
+
+  /* The below tweaks make the print version have multiple columns, like the desktop >768 px version. */
+  .col-sm-1, .col-sm-2, .col-sm-3, .col-sm-4, .col-sm-5, .col-sm-6, .col-sm-7, .col-sm-8, .col-sm-9, .col-sm-10, .col-sm-11, .col-sm-12 {
+    float: left;
+  }
+  .col-sm-12 {
+    width: 100%;
+  }
+  .col-sm-11 {
+    width: 91.67%;
+  }
+  .col-sm-10 {
+    width: 83.33%;
+  }
+  .col-sm-9 {
+    width: 75%;
+  }
+  .col-sm-8 {
+    width: 66.67%;
+  }
+  .col-sm-7 {
+    width: 58.33%;
+  }
+  .col-sm-6 {
+    width: 50%;
+  }
+  .col-sm-5 {
+    width: 41.67%;
+  }
+  .col-sm-4 {
+    width: 33.33%;
+  }
+  .col-sm-3 {
+    width: 25%;
+  }
+  .col-sm-2 {
+    width: 16.67%;
+  }
+  .col-sm-1 {
+    width: 8.33%;
+  }
 }


### PR DESCRIPTION
This makes printed version of an incident page (or any other page) look much more presentable than it looks now. I'm still kind of bad at CSS and Bootstrap 3 (and who really cares to learn?), and the result now is imperfect, but it's much better.

I'm doing a few things:
* stopping the restriction of the site's CSS to "screen", so that it applies to "print" as well
* hiding data entry fields (the "no-print" class)
* stopping flex-container columns from stacking, but rather having them stay side-by-side

Before and after are below:

![image](https://github.com/user-attachments/assets/af96aa81-d3f1-4774-ab19-2feb9df423e9)

![image](https://github.com/user-attachments/assets/d5a209f8-f368-4754-8742-5f6d4b1672cd)