### PR TITLE
improve `uv run` instructions in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,8 +80,9 @@ To set up a configuration for development, start by copying the example configur
 
 To build and run the server (for development only)::
 
-    uv run ims server
-
+    uv run ims --log-file=- --config=./conf/imsd.conf server
+    # or, with debug log-level:
+    uv run ims --log-file=- --config=./conf/imsd.conf --log-level=debug server
 
 ---------------------
 Settings Permissions


### PR DESCRIPTION
The --log-file=- is needed so that stderr gets logged to the terminal, and --config is required by the IMS server to actually start.