### PR TITLE
stop using event.returnValue

### DIFF
--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -35,7 +35,6 @@ function initIncidentPage() {
         window.addEventListener('beforeunload', function (e) {
             if (document.getElementById("incident_report_add").value !== '') {
                 e.preventDefault();
-                e.returnValue = '';
             }
         });
     }

--- a/src/ims/element/static/incident_report.js
+++ b/src/ims/element/static/incident_report.js
@@ -28,7 +28,6 @@ function initIncidentReportPage() {
         window.addEventListener('beforeunload', function (e) {
             if (document.getElementById("incident_report_add").value !== '') {
                 e.preventDefault();
-                e.returnValue = '';
             }
         });
     }


### PR DESCRIPTION
This JavaScript feature is deprecated and doesn't seem to actually do anything.