### PR TITLE
add warning banner on non-prod IMS instances

### DIFF
--- a/src/ims/config/_config.py
+++ b/src/ims/config/_config.py
@@ -399,6 +399,10 @@ class Configuration:
             )
         )
 
+        deployment = parser.valueFromConfig(
+            "DEPLOYMENT", "Core", "Deployment", "Dev"
+        )
+
         #
         # Persist some objects
         #
@@ -408,6 +412,7 @@ class Configuration:
             configFile=configFile,
             configRoot=configRoot,
             dataRoot=dataRoot,
+            deployment=deployment,
             directory=directory,
             hostName=hostName,
             imsAdmins=imsAdmins,
@@ -427,6 +432,7 @@ class Configuration:
     configFile: Path | None
     configRoot: Path
     dataRoot: Path
+    deployment: str
     directory: IMSDirectory
     hostName: str
     imsAdmins: frozenset[str]
@@ -482,6 +488,7 @@ class Configuration:
             f"Core.ConfigRoot: {self.configRoot}\n"
             f"Core.DataRoot: {self.dataRoot}\n"
             f"Core.CachedResources: {self.cachedResourcesRoot}\n"
+            f"Core.Deployment: {self.deployment}\n"
             f"Core.LogLevel: {self.logLevelName}\n"
             f"Core.LogFile: {self.logFilePath}\n"
             f"Core.LogFormat: {self.logFormat}\n"

--- a/src/ims/config/test/test_config.py
+++ b/src/ims/config/test/test_config.py
@@ -780,6 +780,7 @@ class ConfigurationTests(TestCase):
             f"Core.ConfigRoot: {config.configRoot}\n"
             f"Core.DataRoot: {config.dataRoot}\n"
             f"Core.CachedResources: {config.cachedResourcesRoot}\n"
+            f"Core.Deployment: {config.deployment}\n"
             f"Core.LogLevel: {config.logLevelName}\n"
             f"Core.LogFile: {config.logFilePath}\n"
             f"Core.LogFormat: {config.logFormat}\n"

--- a/src/ims/element/_element.py
+++ b/src/ims/element/_element.py
@@ -150,6 +150,20 @@ class Element(BaseElement):
         else:
             return tag(username)
 
+    @renderer
+    def deployment_warning(
+        self, request: IRequest, tag: Tag
+    ) -> KleinRenderable:
+        deployment = self.config.deployment.lower()
+        if deployment == "prod":
+            return ""
+        return tag(
+            tags.p(
+                f"☢️ This is not production. "
+                f"You are on a {deployment} IMS server. ☢️"
+            )
+        )
+
     ##
     # Data
     ##

--- a/src/ims/element/page/nav/template.xhtml
+++ b/src/ims/element/page/nav/template.xhtml
@@ -48,4 +48,7 @@
 
   </div>
 
+  <div class="bg-danger text-center" t:render="deployment_warning">
+  </div>
+
 </nav>


### PR DESCRIPTION
Frankenstein already added the relevant env var to prod and staging

https://github.com/burningmantech/ranger-ims-server/issues/1366

Example below. The banner only shows up if the deployment is not prod.

<img width="760" alt="image" src="https://github.com/user-attachments/assets/21c7494a-2643-49fc-a255-ac1af3d068c3">
