### PR TITLE
skip "Add comment if optional job failed" step for master merges

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -261,7 +261,9 @@ jobs:
           path: .tox/${TOX_ENV}/log/trial.log
 
       - name: Add comment if optional job failed; delete otherwise
-        if: ${{ matrix.optional }}
+        # this step fails on post-merge runs on master, since there's no
+        # PR to comment against.
+        if: ${{ matrix.optional && github.ref != 'refs/heads/master' }}
         uses: thollander/actions-comment-pull-request@v3
         with:
           # Note: tag must be unique to each matrix case


### PR DESCRIPTION
This step always fails on post-merge runs, with
Error: No issue/pull request in input neither in current context.

If the intention is to just comment on pre-merge PR run failures, then this step is doing us no good anyway in that scenario.