### PR TITLE
exclude system entries from calls for all incidents and incident reports

### DIFF
--- a/src/ims/element/incident/incidents/template.xhtml
+++ b/src/ims/element/incident/incidents/template.xhtml
@@ -12,7 +12,7 @@
     var eventID        = <json t:render="event_id"        />;
 
     var pageTemplateURL        = url_viewIncidentsTemplate;
-    var dataURL                = urlReplace(url_incidents);
+    var dataURL                = urlReplace(url_incidents + "?exclude_system_entries=true");
     var viewIncidentsURL       = urlReplace(url_viewIncidents);
     var viewIncidentReportsURL = urlReplace(url_viewIncidentReports);
 

--- a/src/ims/element/static/incident_reports.js
+++ b/src/ims/element/static/incident_reports.js
@@ -115,7 +115,7 @@ function initDataTables() {
         "processing": true,
         "scrollX": false, "scrollY": false,
         "ajax": {
-            "url": urlReplace(url_incidentReports, eventID),
+            "url": urlReplace(url_incidentReports + "?exclude_system_entries=true", eventID),
             "dataSrc": dataHandler,
             "error": function (request, status, error) {
                 // The "abort" case is a special snowflake.

--- a/src/ims/element/static/incidents.js
+++ b/src/ims/element/static/incidents.js
@@ -90,7 +90,7 @@ function loadEventIncidentReports(success) {
         setErrorMessage(message);
     }
 
-    jsonRequest(urlReplace(url_incidentReports), null, ok, fail);
+    jsonRequest(urlReplace(url_incidentReports + "?exclude_system_entries=true"), null, ok, fail);
 
     console.log("Loaded event incident reports");
     if (incidentsTable != null) {

--- a/src/ims/store/_abc.py
+++ b/src/ims/store/_abc.py
@@ -162,7 +162,9 @@ class IMSDataStore(ABC):
     ###
 
     @abstractmethod
-    async def incidents(self, eventID: str) -> Iterable[Incident]:
+    async def incidents(
+        self, eventID: str, excludeSystemEntries: bool
+    ) -> Iterable[Incident]:
         """
         Look up all incidents for the given event.
         """
@@ -321,7 +323,9 @@ class IMSDataStore(ABC):
     ###
 
     @abstractmethod
-    async def incidentReports(self, eventID: str) -> Iterable[IncidentReport]:
+    async def incidentReports(
+        self, eventID: str, excludeSystemEntries: bool
+    ) -> Iterable[IncidentReport]:
         """
         Look up all incident reports in the given event.
         """

--- a/src/ims/store/export/_json.py
+++ b/src/ims/store/export/_json.py
@@ -112,8 +112,8 @@ class JSONExporter:
         )
 
         concentricStreets = await self.store.concentricStreets(event.id)
-        incidents = await self.store.incidents(event.id)
-        incidentReports = await self.store.incidentReports(event.id)
+        incidents = await self.store.incidents(event.id, False)
+        incidentReports = await self.store.incidentReports(event.id, False)
 
         return EventData(
             event=event,
@@ -222,7 +222,7 @@ class JSONImporter:
 
         existingIncidentNumbers = frozenset(
             incident.number
-            for incident in await store.incidents(eventData.event.id)
+            for incident in await store.incidents(eventData.event.id, False)
         )
 
         for incident in eventData.incidents:
@@ -244,7 +244,7 @@ class JSONImporter:
         existingIncidentReportNumbers = frozenset(
             incidentReport.number
             for incidentReport in await store.incidentReports(
-                eventData.event.id
+                eventData.event.id, False
             )
         )
 

--- a/src/ims/store/export/test/test_json.py
+++ b/src/ims/store/export/test/test_json.py
@@ -224,8 +224,10 @@ class JSONImporterTests(TestCase):
                     concentricStreets=resultOf(
                         store.concentricStreets(event.id)
                     ),
-                    incidents=resultOf(store.incidents(event.id)),
-                    incidentReports=resultOf(store.incidentReports(event.id)),
+                    incidents=resultOf(store.incidents(event.id, False)),
+                    incidentReports=resultOf(
+                        store.incidentReports(event.id, False)
+                    ),
                 )
                 for event in resultOf(store.events())
             ),

--- a/src/ims/store/mysql/_queries.py
+++ b/src/ims/store/mysql/_queries.py
@@ -271,6 +271,7 @@ queries = Queries(
                 on re.ID = ire.REPORT_ENTRY
         where
             ire.EVENT = ({query_eventID})
+            and re.GENERATED <= %(generatedLTE)s
         ;
         """,
     ),
@@ -451,6 +452,7 @@ queries = Queries(
                 on irre.REPORT_ENTRY = re.ID
         where
             irre.EVENT = ({query_eventID})
+            and re.GENERATED <= %(generatedLTE)s
         """,
     ),
     createIncidentReport=Query(

--- a/src/ims/store/sqlite/_queries.py
+++ b/src/ims/store/sqlite/_queries.py
@@ -265,6 +265,7 @@ queries = Queries(
                 on re.ID = ire.REPORT_ENTRY
         where
             ire.EVENT = ({query_eventID})
+            and re.GENERATED <= :generatedLTE
         ;
         """,
     ),
@@ -443,6 +444,7 @@ queries = Queries(
                 on irre.REPORT_ENTRY = re.ID
         where
             irre.EVENT = ({query_eventID})
+            and re.GENERATED <= :generatedLTE
         """,
     ),
     createIncidentReport=Query(

--- a/src/ims/store/test/incident.py
+++ b/src/ims/store/test/incident.py
@@ -144,7 +144,7 @@ class DataStoreIncidentTests(DataStoreTests):
 
             found: set[tuple[str, int]] = set()
             for eventID in events:
-                for retrieved in await store.incidents(eventID):
+                for retrieved in await store.incidents(eventID, False):
                     self.assertIncidentsEqual(
                         store, retrieved, events[eventID][retrieved.number]
                     )
@@ -174,7 +174,7 @@ class DataStoreIncidentTests(DataStoreTests):
 
             assert eventID is not None
 
-            retrieved = await store.incidents(eventID)
+            retrieved = await store.incidents(eventID, False)
 
             for r, i in zip(sorted(retrieved), sorted(incidents), strict=True):
                 self.assertIncidentsEqual(store, r, i)
@@ -190,7 +190,7 @@ class DataStoreIncidentTests(DataStoreTests):
         store.bringThePain()
 
         try:
-            await store.incidents(anEvent.id)
+            await store.incidents(anEvent.id, False)
         except StorageError as e:
             self.assertEqual(str(e), store.exceptionMessage)
         else:
@@ -337,7 +337,7 @@ class DataStoreIncidentTests(DataStoreTests):
                 expectedIncidents = sorted(
                     i for i in expectedStoredIncidents if i.eventID == event.id
                 )
-                storedIncidents = sorted(await store.incidents(event.id))
+                storedIncidents = sorted(await store.incidents(event.id, False))
 
                 self.assertEqual(
                     len(storedIncidents),

--- a/src/ims/store/test/report.py
+++ b/src/ims/store/test/report.py
@@ -118,7 +118,9 @@ class DataStoreIncidentReportTests(DataStoreTests):
                 )
 
             found: set[int] = set()
-            for retrieved in await store.incidentReports(anIncident1.eventID):
+            for retrieved in await store.incidentReports(
+                anIncident1.eventID, False
+            ):
                 self.assertIn(retrieved.number, incidentReportsByNumber)
                 self.assertIncidentReportsEqual(
                     store,
@@ -140,7 +142,7 @@ class DataStoreIncidentReportTests(DataStoreTests):
         store.bringThePain()
 
         try:
-            await store.incidentReports(anEvent.id)
+            await store.incidentReports(anEvent.id, False)
         except StorageError as e:
             self.assertEqual(str(e), store.exceptionMessage)
         else:
@@ -248,7 +250,7 @@ class DataStoreIncidentReportTests(DataStoreTests):
                 nextNumber += 1
 
             storedIncidentReports = sorted(
-                await store.incidentReports(anEvent.id)
+                await store.incidentReports(anEvent.id, False)
             )
 
             self.assertEqual(


### PR DESCRIPTION
This does not change the default behavior of the APIs, as this adds a new query param that must be set to "true" to get the new behavior.

This change should make the incidents page/table load noticeably faster, since we'll put less pressure on the server, and the data retrieval will drop from around 4 MB to 2 MB. Additionally, the client-side search should be faster, because we'll be searching over much less unnecessary text.

https://github.com/burningmantech/ranger-ims-server/issues/1375