### PR TITLE
sort the incident page's lists of handles and incident types

### DIFF
--- a/src/ims/element/static/ims.js
+++ b/src/ims/element/static/ims.js
@@ -571,6 +571,11 @@ function shortDescribeLocation(location) {
 // DataTables rendering
 //
 
+function renderSorted(strings) {
+    const copy = strings.toSorted((a, b) => a.localeCompare(b));
+    return copy.join(", ")
+}
+
 function renderIncidentNumber(incidentNumber, type, incident) {
     switch (type) {
         case "display":

--- a/src/ims/element/static/incidents.js
+++ b/src/ims/element/static/incidents.js
@@ -211,7 +211,7 @@ function initDataTables() {
                 "className": "incident_ranger_handles",
                 "data": "ranger_handles",
                 "defaultContent": "",
-                "render": "[, ]",  // Join array with ", "
+                "render": renderSorted,
                 "width": "6em",
             },
             {   // 5
@@ -226,7 +226,7 @@ function initDataTables() {
                 "className": "incident_types",
                 "data": "incident_types",
                 "defaultContent": "",
-                "render": "[, ]",  // Join array with ", "
+                "render": renderSorted,
                 "width": "5em",
             },
             {   // 7


### PR DESCRIPTION
These currently show up in the order they're returned from the API, which is effectively random, due to this issue:
https://github.com/burningmantech/ranger-ims-server/issues/1348

We might as well do client-side sorting even if we also do something on the server-side too.