### PR TITLE
sanitize some more strings

### DIFF
--- a/src/ims/element/static/admin_types.js
+++ b/src/ims/element/static/admin_types.js
@@ -108,8 +108,9 @@ function updateIncidentTypes() {
             entryItem.addClass("item-visible")
         }
 
-        entryItem.append(incidentType);
-        entryItem.attr("value", incidentType);
+        const safeIncidentType = textAsHTML(incidentType);
+        entryItem.append(safeIncidentType);
+        entryItem.attr("value", safeIncidentType);
 
         entryContainer.append(entryItem);
     }

--- a/src/ims/element/static/ims.js
+++ b/src/ims/element/static/ims.js
@@ -571,8 +571,9 @@ function shortDescribeLocation(location) {
 // DataTables rendering
 //
 
-function renderSorted(strings) {
-    const copy = strings.toSorted((a, b) => a.localeCompare(b));
+function renderSafeSorted(strings) {
+    const safe = strings.map(s => textAsHTML(s));
+    const copy = safe.toSorted((a, b) => a.localeCompare(b));
     return copy.join(", ")
 }
 

--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -550,8 +550,8 @@ function drawRangers() {
             ranger = rangerAsString(personnel[handle]);
         }
         var item = _rangerItem.clone();
-        item.append(ranger);
-        item.attr("value", handle);
+        item.append(textAsHTML(ranger));
+        item.attr("value", textAsHTML(handle));
         items.push(item);
     }
 
@@ -625,7 +625,7 @@ function drawIncidentTypes() {
 
     for (var i in incidentTypes) {
         var item = _typesItem.clone();
-        item.append(incidentTypes[i]);
+        item.append(textAsHTML(incidentTypes[i]));
         items.push(item);
     }
 

--- a/src/ims/element/static/incidents.js
+++ b/src/ims/element/static/incidents.js
@@ -211,7 +211,7 @@ function initDataTables() {
                 "className": "incident_ranger_handles",
                 "data": "ranger_handles",
                 "defaultContent": "",
-                "render": renderSorted,
+                "render": renderSafeSorted,
                 "width": "6em",
             },
             {   // 5
@@ -226,7 +226,7 @@ function initDataTables() {
                 "className": "incident_types",
                 "data": "incident_types",
                 "defaultContent": "",
-                "render": renderSorted,
+                "render": renderSafeSorted,
                 "width": "5em",
             },
             {   // 7


### PR DESCRIPTION
Ranger handles and incident types can't really be trusted as safe, since anyone can bypass client-side checks and set the incident types or ranger handles to anything on an incident.