### PR TITLE
permit any calls to codecov.io

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -188,16 +188,14 @@ jobs:
           disable-file-monitoring: true
           egress-policy: block
           allowed-endpoints: >
-            api.codecov.io:443
+            *.codecov.io:443
             api.github.com:443
-            cli.codecov.io:443
             codecov.io:443
             files.pythonhosted.org:443
             github.com:443
             objects.githubusercontent.com:443
             pypi.org:443
             storage.googleapis.com:443
-            uploader.codecov.io:443
 
       - name: Checkout source code
         uses: actions/checkout@v4


### PR DESCRIPTION
There are apparently new calls in the codecov step to ingest.codecov.io,
and now all my CI runs are failing 😭.
It seems more futureproofed and minimally risky to just permit calls to any
subdomain of codecov.io

https://app.stepsecurity.io/github/burningmantech/ranger-ims-server/actions/runs/11836661205?jobid=32982019292&tab=network-events

https://github.com/codecov/codecov-action/issues/1547#issuecomment-2476267485