### PR TITLE
api: attach incident reports when creating incident

### DIFF
--- a/src/ims/application/_api.py
+++ b/src/ims/application/_api.py
@@ -522,11 +522,13 @@ class APIApplication:
             "New incident: {json}", json=jsonObjectFromModelObject(incident)
         )
 
-        request.setHeader("X-IMS-Incident-Number", str(incident.number))
-        request.setHeader(
-            HeaderName.location.value,
-            URLs.incidents.child(str(incident.number)).asText(),
+        location = (
+            URLs.incidents.child(str(incident.number))
+            .asText()
+            .replace("<event_id>", event_id)
         )
+        request.setHeader(HeaderName.location.value, location)
+        request.setHeader("X-IMS-Incident-Number", str(incident.number))
         return noContentResponse(request)
 
     @router.route(_unprefix(URLs.incidentNumber), methods=("HEAD", "GET"))

--- a/src/ims/store/_db.py
+++ b/src/ims/store/_db.py
@@ -1093,6 +1093,19 @@ class DatabaseStore(IMSDataStore):
             )
             raise
 
+        # Attach incident number to any incident reports
+        for irn in incident.incidentReportNumbers:
+            if not author:
+                continue
+            await self._setIncidentReportAttribute(
+                self.query.attachIncidentReportToIncident.text,
+                incident.eventID,
+                irn,
+                "incident_number",
+                incident.number,
+                author,
+            )
+
         self._log.info(
             "Created incident {incident}",
             incident=incident,


### PR DESCRIPTION
Previously the call to create an incident report ignored any incident report numbers that were set in the request.

I want to have this in order to address Porcupine's request here https://github.com/burningmantech/ranger-ims-server/issues/372#issuecomment-1519171659