### PR TITLE
do descending sort order on FRs to attach to incident

### DIFF
--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -344,10 +344,10 @@ function loadUnattachedIncidentReports(success) {
         for (const d of data) {
             _unattachedIncidentReports.push(d);
         }
-        // apply an ascending sort based on the field report number,
+        // apply a descending sort based on the field report number,
         // being cautious about field report number being null
         _unattachedIncidentReports.sort(function (a, b) {
-            return (a.number ?? -1) - (b.number ?? -1);
+            return (b.number ?? -1) - (a.number ?? -1);
         })
         unattachedIncidentReports = _unattachedIncidentReports;
 


### PR DESCRIPTION
This seems like a more useful ordering, since most of the time, the user will be wanting to attach a recently-made FR, rather than the oldest ones.