### PR TITLE
hide incident history by default

### DIFF
--- a/src/ims/element/incident/incident_template/template.xhtml
+++ b/src/ims/element/incident/incident_template/template.xhtml
@@ -216,7 +216,7 @@
       <label class="control-label">Incident Details</label>
       <div id="incident_report_well" class="well well-sm">
         <label class="control-label">
-          <input id="history_checkbox" type="checkbox" checked="" onchange="toggleShowHistory()" />
+          <input id="history_checkbox" type="checkbox" onchange="toggleShowHistory()" />
           Show history
         </label>
         <label class="control-label">


### PR DESCRIPTION
There's been feedback from the Operator Delegation that the system- generated history is usually more noise than signal, and that it would be preferable for it to not be displayed by default.