### PR TITLE
allow creation of new Incident from Field Report page

### DIFF
--- a/src/ims/element/incident/report/_report.py
+++ b/src/ims/element/incident/report/_report.py
@@ -69,3 +69,14 @@ class IncidentReportPage(Page):
         JSON integer: incident report number.
         """
         return jsonTextFromObject(self.number)
+
+    @renderer
+    def can_write_incidents(self, request: IRequest, tag: Tag) -> KleinRenderable:
+        return (
+            jsonTrue
+            if (
+                request.authorizations  # type: ignore[attr-defined]
+                & Authorization.writeIncidents
+            )
+            else jsonFalse
+        )

--- a/src/ims/element/incident/report/template.xhtml
+++ b/src/ims/element/incident/report/template.xhtml
@@ -10,6 +10,7 @@
     var editingAllowed       = <json t:render="editing_allowed"        />;
     var eventID              = <json t:render="event_id"               />;
     var incidentReportNumber = <json t:render="incident_report_number" />;
+    var canWriteIncidents    = <json t:render="can_write_incidents" />;
     var pageTemplateURL      = url_viewIncidentReportTemplate;
 
     initIncidentReportPage();

--- a/src/ims/element/incident/report_template/template.xhtml
+++ b/src/ims/element/incident/report_template/template.xhtml
@@ -11,6 +11,18 @@
           <label class="control-label">FR #:</label>
           <span id="incident_report_number" class="form-control-static" />
         </div>
+        <div class="form-group">
+          <label class="control-label">IMS #:</label>
+          <span id="incident_number" class="form-control-static" />
+          <button
+                  id="create_incident"
+                  class="btn btn-sm btn-warning hidden"
+                  title="Only click this if there's no preexisting incident for this FR"
+                  onclick="makeIncident()"
+          >
+            Create new incident from FR
+          </button>
+        </div>
       </div>
   </div>
 


### PR DESCRIPTION
also, show the IMS # on the Field Report page.

as part of this, I had to make some tweaks to authorizeRequestForIncidentReport, since the previous approach wouldn't fully populate the request's authorizations, and so we couldn't tell the web client if it had writeIncidents. That function could very much use some unit testing (it looks like it was left as a TODO, since it's nontrivial to fake out the layers of auth checking invoked there)

BEHAVIOR CHANGE: previously when an **off-site** user had only writeIncidentReports permission AND the global requireActive was True, that user could access any field report upon which they had commented in the past, if they navigated directly to that page. The listFieldReports page, by contrast, would return a "permission denied", since it was respecting the requireActive setting. That seems like a glitch... If requireActive is True and the user is off-site, then the user shouldn't be able to access any page for the event. This PR fixes that glitch, because it was necessary to make the change mentioned in the paragraph above. This is a pretty niche change that I doubt anyone will notice, since you'd have to navigate straight to the field report anyway.


this PR is based on @prqpn 's request here: https://github.com/burningmantech/ranger-ims-server/issues/372#issuecomment-1519171659

and my followup point here: https://github.com/burningmantech/ranger-ims-server/issues/372#issuecomment-2498236814

FYI to @kimballa too
