### PR TITLE
always use tz=UTC for DateTime.now (to fix flakey test)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
     rev: v0.8.0
     hooks:
       - id: ruff
+        args: [ --fix ]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/src/ims/auth/_provider.py
+++ b/src/ims/auth/_provider.py
@@ -19,6 +19,7 @@ Incident Management System web application authentication provider.
 """
 
 from collections.abc import Container, Mapping
+from datetime import UTC
 from datetime import datetime as DateTime
 from datetime import timedelta as TimeDelta
 from enum import Flag, auto
@@ -248,7 +249,7 @@ class AuthProvider:
         return self.directory.verifyPassword(user, password)
 
     def _tokenForUser(self, user: IMSUser, duration: TimeDelta) -> JSONWebToken:
-        now = DateTime.now()
+        now = DateTime.now(tz=UTC)
         expiration = now + duration
         return JSONWebToken.fromClaims(
             JSONWebTokenClaims(

--- a/src/ims/model/strategies.py
+++ b/src/ims/model/strategies.py
@@ -19,6 +19,7 @@ Test strategies for model data.
 """
 
 from collections.abc import Callable, Hashable
+from datetime import UTC
 from datetime import datetime as DateTime
 from datetime import timedelta as TimeDelta
 from datetime import timezone as TimeZone
@@ -128,12 +129,12 @@ def dateTimes(
     fuzz = TimeDelta(days=1)
 
     if beforeNow:
-        max = DateTime.now() - fuzz
+        max = DateTime.now(tz=UTC) - fuzz
     else:
         max = DateTime(9999, 12, 31, 23, 59, 59, 999999)
 
     if fromNow:
-        min = DateTime.now() + fuzz
+        min = DateTime.now(tz=UTC) + fuzz
     else:
         min = DateTime(1970, 1, 1) + fuzz
 


### PR DESCRIPTION
after much time trying to determine why
AuthorizationTests.test_credentialsForUser
was failing some of the time, I figured out
that it's because we were DateTime.now() in
_provider.py, but DateTime.now(tz=UTC) in
test_provider.py. This would lead to an off-by-one-hour bug when a date was calculated in the two places, since, for example,
DateTime.now()+6 months != DateTime(UTC)+6 months
when the local timezone would switch between standard time and daylight saving time in that interval

also this enables auto-fixing for ruff in pre-commit, because that makes formatting easier