### PR TITLE
fix placeholders for incident/field report pages

### DIFF
--- a/src/ims/element/incident/report_template/template.xhtml
+++ b/src/ims/element/incident/report_template/template.xhtml
@@ -84,7 +84,7 @@
         <input
           id="incident_report_summary" class="form-control input-sm"
           type="text" inputmode="latin-prose"
-          placeholder="One-line summary of incident…"
+          placeholder="e.g. Someone did a thing at Camp ABC. IMS#123"
           onchange="editSummary()"
         />
       </div>

--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -510,16 +510,17 @@ function drawPriority() {
 //
 
 function drawSummary() {
-    var summary = incident.summary;
-
-    if (summary == undefined || summary == "") {
-        $("#incident_summary")[0].removeAttribute("value");
-        $("#incident_summary").attr(
-            "placeholder", summarizeIncident(incident)
-        );
-    } else {
-        $("#incident_summary").val(summary);
+    if (incident.summary) {
+        $("#incident_summary").val(incident.summary);
         $("#incident_summary").attr("placeholder", "");
+        return;
+    }
+
+    $("#incident_summary")[0].removeAttribute("value");
+    const summarized = summarizeIncident(incident);
+    if (summarized) {
+        // only replace the placeholder if it would be nonempty
+        $("#incident_summary").attr("placeholder", summarized);
     }
 }
 

--- a/src/ims/element/static/incident_report.js
+++ b/src/ims/element/static/incident_report.js
@@ -212,16 +212,17 @@ function drawIncident() {
 //
 
 function drawSummary() {
-    var summary = incidentReport.summary;
-
-    if (summary == undefined || summary == "") {
-        $("#incident_report_summary")[0].removeAttribute("value");
-        $("#incident_report_summary").attr(
-            "placeholder", summarizeIncident(incidentReport)
-        );
-    } else {
-        $("#incident_report_summary").val(summary);
+    if (incidentReport.summary) {
+        $("#incident_report_summary").val(incidentReport.summary);
         $("#incident_report_summary").attr("placeholder", "");
+        return;
+    }
+
+    $("#incident_report_summary")[0].removeAttribute("value");
+    const summarized = summarizeIncident(incidentReport);
+    if (summarized) {
+        // only replace the placeholder if it would be nonempty
+        $("#incident_report_summary").attr("placeholder", summarized);
     }
 }
 

--- a/src/ims/run/_command.py
+++ b/src/ims/run/_command.py
@@ -111,9 +111,7 @@ class Command:
 
         from twisted.internet import reactor
 
-        cast(IReactorTCP, reactor).listenTCP(  # type: ignore[call-arg]
-            port, factory, interface=host
-        )
+        cast(IReactorTCP, reactor).listenTCP(port, factory, interface=host)
 
     @classmethod
     async def runExport(cls, config: Configuration, options: ExportOptions) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -508,7 +508,7 @@ requires-dist = [
     { name = "pyopenssl", specifier = "==24.3.0" },
     { name = "pyyaml", specifier = "==6.0.2" },
     { name = "service-identity", specifier = "==24.2.0" },
-    { name = "twisted", specifier = "==24.10.0" },
+    { name = "twisted", specifier = "==24.11.0" },
     { name = "werkzeug", specifier = "==3.1.3" },
     { name = "zope-interface", specifier = "==7.2" },
 ]
@@ -599,7 +599,7 @@ wheels = [
 
 [[package]]
 name = "twisted"
-version = "24.10.0"
+version = "24.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -610,9 +610,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "zope-interface" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b2/0f/2d0b0dcd52a849db64ff63619aead94ae1091fe4d4d7e100371efe513585/twisted-24.10.0.tar.gz", hash = "sha256:02951299672595fea0f70fa2d5f7b5e3d56836157eda68859a6ad6492d36756e", size = 3525999 }
+sdist = { url = "https://files.pythonhosted.org/packages/77/1c/e07af0df31229250ab58a943077e4adbd5e227d9f2ac826920416b3e5fa2/twisted-24.11.0.tar.gz", hash = "sha256:695d0556d5ec579dcc464d2856b634880ed1319f45b10d19043f2b57eb0115b5", size = 3526722 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/7c/f80f6853d702782edb357190c42c3973f13c547a5f68ab1b17e6415061b8/twisted-24.10.0-py3-none-any.whl", hash = "sha256:67aa7c8aa94387385302acf44ade12967c747858c8bcce0f11d38077a11c5326", size = 3188753 },
+    { url = "https://files.pythonhosted.org/packages/70/53/a50654eb9c63da0df2b5dca8ec27656a88b7edd798de5ffad55353203874/twisted-24.11.0-py3-none-any.whl", hash = "sha256:fe403076c71f04d5d2d789a755b687c5637ec3bcd3b2b8252d76f2ba65f54261", size = 3188667 },
 ]
 
 [[package]]


### PR DESCRIPTION
these were previously never showing the placeholder text in the template, because they would always get wiped out by an empty "summarizeIncident" response

this also tweaks the field report placeholder summary a bit, to make it more clear what we're asking of the user