### PR TITLE
use a longer minimum test credential duration

### DIFF
--- a/src/ims/auth/test/test_provider.py
+++ b/src/ims/auth/test/test_provider.py
@@ -429,7 +429,7 @@ class AuthProviderTests(TestCase):
 
     @given(
         testUsers(),
-        timedeltas(min_value=TimeDelta(seconds=0), max_value=TimeDelta(days=1000)),
+        timedeltas(min_value=TimeDelta(minutes=10), max_value=TimeDelta(days=1000)),
     )
     def test_credentialsForUser(self, user: IMSUser, duration: TimeDelta) -> None:
         """
@@ -463,7 +463,7 @@ class AuthProviderTests(TestCase):
 
     @given(
         testUsers(),
-        timedeltas(min_value=TimeDelta(seconds=1), max_value=TimeDelta(days=1000)),
+        timedeltas(min_value=TimeDelta(minutes=10), max_value=TimeDelta(days=1000)),
     )
     def test_userFromBearerAuthorization(
         self, user: IMSUser, duration: TimeDelta


### PR DESCRIPTION
I was hit with some flakiness in test_userFromBearerAuthorization in CI, and I suspect it's because the minimum duration for the token in that test was only 1 second. The test fails if the credential is already invalid by the time the code validates it.

https://github.com/burningmantech/ranger-ims-server/actions/runs/12277750464/job/34257848070