### PR TITLE
use icons rather than unicode for theme selectors

### DIFF
--- a/src/ims/element/page/nav/template.xhtml
+++ b/src/ims/element/page/nav/template.xhtml
@@ -2,6 +2,20 @@
 <nav xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" t:render="root"
      class="navbar border rounded navbar-expand-sm bg-body-tertiary">
 
+  <!-- These svgs are courtesy of https://icons.getbootstrap.com/icons/ -->
+  <svg xmlns="http://www.w3.org/2000/svg" class="d-none">
+    <symbol id="circle-half" viewBox="0 0 16 16">
+      <path d="M8 15A7 7 0 1 0 8 1v14zm0 1A8 8 0 1 1 8 0a8 8 0 0 1 0 16z"></path>
+    </symbol>
+    <symbol id="moon-stars-fill" viewBox="0 0 16 16">
+      <path d="M6 .278a.768.768 0 0 1 .08.858 7.208 7.208 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277.527 0 1.04-.055 1.533-.16a.787.787 0 0 1 .81.316.733.733 0 0 1-.031.893A8.349 8.349 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.752.752 0 0 1 6 .278z"></path>
+      <path d="M10.794 3.148a.217.217 0 0 1 .412 0l.387 1.162c.173.518.579.924 1.097 1.097l1.162.387a.217.217 0 0 1 0 .412l-1.162.387a1.734 1.734 0 0 0-1.097 1.097l-.387 1.162a.217.217 0 0 1-.412 0l-.387-1.162A1.734 1.734 0 0 0 9.31 6.593l-1.162-.387a.217.217 0 0 1 0-.412l1.162-.387a1.734 1.734 0 0 0 1.097-1.097l.387-1.162zM13.863.099a.145.145 0 0 1 .274 0l.258.774c.115.346.386.617.732.732l.774.258a.145.145 0 0 1 0 .274l-.774.258a1.156 1.156 0 0 0-.732.732l-.258.774a.145.145 0 0 1-.274 0l-.258-.774a1.156 1.156 0 0 0-.732-.732l-.774-.258a.145.145 0 0 1 0-.274l.774-.258c.346-.115.617-.386.732-.732L13.863.1z"></path>
+    </symbol>
+    <symbol id="sun-fill" viewBox="0 0 16 16">
+      <path d="M8 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0zm0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13zm8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5zM3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8zm10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.415a.5.5 0 1 1-.707-.708l1.414-1.414a.5.5 0 0 1 .707 0zm-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0zm9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707zM4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .708z"></path>
+    </symbol>
+  </svg>
+
   <div class="container-fluid">
     <a class="navbar-brand" t:render="url" url="app">
       IMS
@@ -32,28 +46,28 @@
           <button class="btn btn-link nav-link py-2 px-0 px-lg-2 dropdown-toggle d-flex align-items-center"
                   id="bd-theme" type="button" aria-expanded="false" data-bs-toggle="dropdown"
                   data-bs-display="static" aria-label="Toggle theme (auto)">
-            <span class="bi my-1 theme-icon-active">◑</span>
+            <svg class="bi my-1 theme-icon-active"><use href="#circle-half" /></svg>
             <span class="d-none ms-2" id="bd-theme-text">Toggle theme</span>
           </button>
           <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-theme-text">
             <li>
               <button type="button" class="dropdown-item d-flex align-items-center"
                       data-bs-theme-value="light" aria-pressed="false">
-                <span class="bi me-2 opacity-50">☀️</span>
+                <svg class="bi me-2"><use href="#sun-fill" /></svg>
                 Light
               </button>
             </li>
             <li>
               <button type="button" class="dropdown-item d-flex align-items-center"
                       data-bs-theme-value="dark" aria-pressed="false">
-                <span class="bi me-2 opacity-50">🌙</span>
+                <svg class="bi me-2"><use href="#moon-stars-fill" /></svg>
                 Dark
               </button>
             </li>
             <li>
               <button type="button" class="dropdown-item d-flex align-items-center active"
                       data-bs-theme-value="auto" aria-pressed="true">
-                <span class="bi me-2 opacity-50">◑</span>
+                <svg class="bi me-2"><use href="#circle-half" /></svg>
                 Auto
               </button>
             </li>

--- a/src/ims/element/static/ims.js
+++ b/src/ims/element/static/ims.js
@@ -46,9 +46,9 @@ function applyTheme() {
         }
 
         const themeSwitcherText = document.querySelector("#bd-theme-text");
-        const activeThemeIcon = document.querySelector(".theme-icon-active");
+        const activeThemeIcon = document.querySelector(".theme-icon-active use");
         const btnToActive = document.querySelector(`[data-bs-theme-value="${theme}"]`);
-        const svgOfActiveBtn = btnToActive.querySelector('span').textContent;
+        const svgOfActiveBtn = btnToActive.querySelector("svg use").getAttribute("href");
 
         document.querySelectorAll("[data-bs-theme-value]").forEach(element => {
             element.classList.remove("active");
@@ -57,7 +57,7 @@ function applyTheme() {
 
         btnToActive.classList.add("active");
         btnToActive.setAttribute("aria-pressed", "true");
-        activeThemeIcon.textContent = svgOfActiveBtn;
+        activeThemeIcon.setAttribute('href', svgOfActiveBtn);
         const themeSwitcherLabel = `${themeSwitcherText.textContent} (${btnToActive.dataset.bsThemeValue})`;
         themeSwitcher.setAttribute("aria-label", themeSwitcherLabel);
 

--- a/src/ims/element/static/style.css
+++ b/src/ims/element/static/style.css
@@ -243,6 +243,13 @@ h1 {
   display: none;
 }
 
+.bi {
+  width: 1em;
+  height: 1em;
+  vertical-align: -.125em;
+  fill: currentcolor
+}
+
 @media print {
   .no-print {
     display: none;


### PR DESCRIPTION
These look prettier, and won't vary based on system font

e.g. before

<img width="191" alt="image" src="https://github.com/user-attachments/assets/3b653929-5723-43ea-bdcd-256c8a730ce3" />
<img width="206" alt="image" src="https://github.com/user-attachments/assets/8a87d4ad-337e-4e9c-84b0-d539a0f20ea8" />

after

<img width="188" alt="image" src="https://github.com/user-attachments/assets/6ec18e91-8313-4606-b02f-5fa2f20cd040" />
<img width="192" alt="image" src="https://github.com/user-attachments/assets/f3157455-c813-4bfe-8c4c-418fee62477a" />
