### PR TITLE
don't send Set-Cookie back from eventsource calls

### DIFF
--- a/src/ims/application/_api.py
+++ b/src/ims/application/_api.py
@@ -1119,6 +1119,11 @@ class APIApplication:
         """
         self._log.debug("Event source connected: {id}", id=id(request))
 
+        # Clear the cookies on the response. Without this here, the eventsource
+        # call will often return Set-Cookie values that lead clients to stomp
+        # over authenticated session cookies with unauthenticated ones.
+        request.cookies = []  # type: ignore[attr-defined]
+
         request.setHeader(HeaderName.contentType.value, ContentType.eventStream.value)
 
         self.storeObserver.addListener(request)


### PR DESCRIPTION
this fixes the below issue, in a minimally hacky way.
The eventsource call doesn't require authentication, and
when a client does automatic connection retries on this
endpoint, it'll sometimes get back a Set-Cookie value
for a brand new, unauthenticated Twisted session. That
cookie value can stomp over a valid, authenticated session
cookie that the client may already have. The result is that
a user can effectively be logged out after a session lasting
less than a minute. That's not desirable.

https://github.com/burningmantech/ranger-ims-server/issues/1363