### PR TITLE
remove "Ranger" from home/login page titles

### DIFF
--- a/src/ims/element/login/_login.py
+++ b/src/ims/element/login/_login.py
@@ -35,7 +35,7 @@ class LoginPage(Page):
     Login page.
     """
 
-    name: str = "Ranger Incident Management System"
+    name: str = "Incident Management System"
     failed: bool = False
 
     @renderer

--- a/src/ims/element/root/_root.py
+++ b/src/ims/element/root/_root.py
@@ -32,4 +32,4 @@ class RootPage(Page):
     Server root page.
     """
 
-    name: str = "Ranger Incident Management System"
+    name: str = "Incident Management System"


### PR DESCRIPTION
it's ugly that this title is long enough that it splits onto two lines on mobile devices (see screenshot). It's prettier to just drop the "Ranger". It should still be obvious enough for users that this is a BRR system

<img width="423" alt="image" src="https://github.com/user-attachments/assets/ac40d66a-8fcd-4b65-9af4-c2a7f0124d42" />
