### PR TITLE
rename "incident report" to "field report" in API and auth

### DIFF
--- a/src/ims/application/_web.py
+++ b/src/ims/application/_web.py
@@ -94,7 +94,7 @@ class WebApplication:
             url = URLs.viewIncidentsRelative
         except NotAuthorizedError:
             await self.config.authProvider.authorizeRequest(
-                request, event_id, Authorization.writeIncidentReports
+                request, event_id, Authorization.writeFieldReports
             )
             url = URLs.viewFieldReportsRelative
 
@@ -223,7 +223,7 @@ class WebApplication:
             )
         except NotAuthorizedError:
             await self.config.authProvider.authorizeRequest(
-                request, event_id, Authorization.writeIncidentReports
+                request, event_id, Authorization.writeFieldReports
             )
         event = Event(id=event_id)
         return FieldReportsPage(config=self.config, event=event)
@@ -247,7 +247,7 @@ class WebApplication:
         config = self.config
         if number == "new":
             await config.authProvider.authorizeRequest(
-                request, event_id, Authorization.writeIncidentReports
+                request, event_id, Authorization.writeFieldReports
             )
             incidentReportNumber = None
             del number

--- a/src/ims/auth/test/test_provider.py
+++ b/src/ims/auth/test/test_provider.py
@@ -677,15 +677,15 @@ class AuthProviderTests(TestCase):
 
         # Stage 2: the user is now a reporter
         self.successResultOf(store.setReporters(event, (personUser,)))
-        # Now the user is able to writeIncidentReports, but that's it
+        # Now the user is able to writeFieldReports, but that's it
         self.successResultOf(
             provider.authorizeRequest(
                 request=request,
                 eventID=event,
-                requiredAuthorizations=Authorization.writeIncidentReports,
+                requiredAuthorizations=Authorization.writeFieldReports,
             )
         )
-        self.assertEqual(request.authorizations, Authorization.writeIncidentReports)
+        self.assertEqual(request.authorizations, Authorization.writeFieldReports)
         self.failureResultOf(
             provider.authorizeRequest(
                 request=request,
@@ -725,7 +725,7 @@ class AuthProviderTests(TestCase):
             Authorization.readPersonnel
             | Authorization.readIncidents
             | Authorization.writeIncidents
-            | Authorization.writeIncidentReports,
+            | Authorization.writeFieldReports,
         )
 
         # Stage 5: no event is provided in the request
@@ -797,7 +797,7 @@ class AuthProviderTests(TestCase):
             reportEntries=(),
         )
 
-        # Stage 1: user doesn't have writeIncidentReports, so no incident
+        # Stage 1: user doesn't have writeFieldReports, so no incident
         # report can be read.
         self.failureResultOf(
             provider.authorizeRequestForIncidentReport(
@@ -816,7 +816,7 @@ class AuthProviderTests(TestCase):
                 incidentReport=reportByUser,
             ),
         )
-        self.assertEqual(request.authorizations, Authorization.writeIncidentReports)
+        self.assertEqual(request.authorizations, Authorization.writeFieldReports)
         self.failureResultOf(
             provider.authorizeRequestForIncidentReport(
                 request=request,
@@ -824,7 +824,7 @@ class AuthProviderTests(TestCase):
             ),
             NotAuthorizedError,
         )
-        self.assertEqual(request.authorizations, Authorization.writeIncidentReports)
+        self.assertEqual(request.authorizations, Authorization.writeFieldReports)
 
         # Stage 3: user is a reader
         self.successResultOf(store.setReporters(event, ()))
@@ -860,7 +860,7 @@ class AuthProviderTests(TestCase):
             Authorization.readPersonnel
             | Authorization.readIncidents
             | Authorization.writeIncidents
-            | Authorization.writeIncidentReports,
+            | Authorization.writeFieldReports,
         )
 
 

--- a/src/ims/config/_urls.py
+++ b/src/ims/config/_urls.py
@@ -54,8 +54,8 @@ class URLs:
     event: ClassVar[URL] = events.child("<event_id>").child("")
     incidents: ClassVar[URL] = event.child("incidents").child("")
     incidentNumber: ClassVar[URL] = incidents.child("<incident_number>")
-    incidentReports: ClassVar[URL] = event.child("incident_reports").child("")
-    incidentReport: ClassVar[URL] = incidentReports.child("<incident_report_number>")
+    fieldReports: ClassVar[URL] = event.child("incident_reports").child("")
+    fieldReport: ClassVar[URL] = fieldReports.child("<field_report_number>")
 
     eventSource: ClassVar[URL] = api.child("eventsource")
 

--- a/src/ims/element/_element.py
+++ b/src/ims/element/_element.py
@@ -221,7 +221,7 @@ class Element(BaseElement):
         )
 
         relevantAuthorizations = (
-            Authorization.readIncidents | Authorization.writeIncidentReports
+            Authorization.readIncidents | Authorization.writeFieldReports
         )
 
         eventIDs = order(

--- a/src/ims/element/incident/report/_report.py
+++ b/src/ims/element/incident/report/_report.py
@@ -51,7 +51,7 @@ class FieldReportPage(Page):
         """
         if (
             request.authorizations  # type: ignore[attr-defined]
-            & Authorization.writeIncidentReports
+            & Authorization.writeFieldReports
         ):
             return jsonTrue
         return jsonFalse

--- a/src/ims/element/incident/reports/_reports.py
+++ b/src/ims/element/incident/reports/_reports.py
@@ -50,7 +50,7 @@ class FieldReportsPage(Page):
         """
         if (
             request.authorizations  # type: ignore[attr-defined]
-            & Authorization.writeIncidentReports
+            & Authorization.writeFieldReports
         ):
             return jsonTrue
         return jsonFalse

--- a/src/ims/element/static/field_report.js
+++ b/src/ims/element/static/field_report.js
@@ -124,7 +124,7 @@ function loadFieldReport(success) {
             "created": null,
         });
     } else {
-        const url = urlReplace(url_incidentReports) + number;
+        const url = urlReplace(url_fieldReports) + number;
         jsonRequest(url, null, ok, fail);
     }
 }
@@ -235,7 +235,7 @@ function drawSummary() {
 
 function sendEdits(edits, success, error) {
     const number = fieldReport.number;
-    let url = urlReplace(url_incidentReports);
+    let url = urlReplace(url_fieldReports);
 
     if (number == null) {
         // We're creating a new field report.
@@ -321,7 +321,7 @@ function makeIncident() {
         fieldReport.incident = parseInt(newIncident);
 
         const url = (
-            urlReplace(url_incidentReports) + fieldReport.number +
+            urlReplace(url_fieldReports) + fieldReport.number +
             "?action=attach;incident=" + newIncident
         );
 

--- a/src/ims/element/static/field_reports.js
+++ b/src/ims/element/static/field_reports.js
@@ -127,7 +127,7 @@ function initDataTables() {
             // per-user authorization can exclude field reports entirely from
             // someone who created an field report but then didn't add an
             // entry to it.
-            "url": urlReplace(url_incidentReports, eventID),
+            "url": urlReplace(url_fieldReports, eventID),
             "dataSrc": dataHandler,
             "error": function (request, status, error) {
                 // The "abort" case is a special snowflake.

--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -365,7 +365,7 @@ function loadUnattachedFieldReports(success) {
     }
 
     jsonRequest(
-        urlReplace(url_incidentReports),
+        urlReplace(url_fieldReports),
         null, ok, fail,
     );
 }
@@ -397,7 +397,7 @@ function loadAttachedFieldReports(success) {
     }
 
     const url = (
-        urlReplace(url_incidentReports) + "?incident=" + incidentNumber
+        urlReplace(url_fieldReports) + "?incident=" + incidentNumber
     );
 
     jsonRequest(url, null, ok, fail);
@@ -1112,7 +1112,7 @@ function detachFieldReport(sender) {
     }
 
     const url = (
-        urlReplace(url_incidentReports) + fieldReport.number +
+        urlReplace(url_fieldReports) + fieldReport.number +
         "?action=detach;incident=" + incidentNumber
     );
 
@@ -1144,7 +1144,7 @@ function attachFieldReport() {
     }
 
     const url = (
-        urlReplace(url_incidentReports) + fieldReportNumber +
+        urlReplace(url_fieldReports) + fieldReportNumber +
         "?action=attach;incident=" + incidentNumber
     );
 

--- a/src/ims/element/static/incidents.js
+++ b/src/ims/element/static/incidents.js
@@ -90,7 +90,7 @@ function loadEventFieldReports(success) {
         setErrorMessage(message);
     }
 
-    jsonRequest(urlReplace(url_incidentReports + "?exclude_system_entries=true"), null, ok, fail);
+    jsonRequest(urlReplace(url_fieldReports + "?exclude_system_entries=true"), null, ok, fail);
 
     console.log("Loaded event field reports");
     if (incidentsTable != null) {


### PR DESCRIPTION
this does actually change an API path, but it doesn't look like ranger-ims-web uses that path
yet, so there's nothing to change over there.

https://github.com/burningmantech/ranger-ims-server/issues/1469