### PR TITLE
use JS altKey and ctrlKey to simplify hotkey code

### DIFF
--- a/src/ims/element/static/field_report.js
+++ b/src/ims/element/static/field_report.js
@@ -41,35 +41,16 @@ function initFieldReportPage() {
         disableEditing();
         loadAndDisplayFieldReport(loadedFieldReport);
 
-        let command = false;
-
-        function addFieldKeyDown() {
-            const keyCode = event.keyCode;
-
-            // 17 = control, 18 = option
-            if (keyCode === 17 || keyCode === 18) {
-                command = true;
-            }
-
-            // console.warn(keyCode);
-        }
-
-        function addFieldKeyUp() {
-            const keyCode = event.keyCode;
-
-            // 17 = control, 18 = option
-            if (keyCode === 17 || keyCode === 18) {
-                command = false;
-                return;
-            }
-
-            // 13 = return
-            if (command && keyCode === 13) {
-                submitReportEntry();
+        function addFieldKeyUp(e) {
+            // holding alt/option or ctrl
+            if (e.altKey || e.ctrlKey) {
+                // 13 = return
+                if (e.keyCode === 13) {
+                    submitReportEntry();
+                }
             }
         }
 
-        $("#report_entry_add")[0].onkeydown = addFieldKeyDown;
         $("#report_entry_add")[0].onkeyup   = addFieldKeyUp;
     }
 

--- a/src/ims/element/static/field_reports.js
+++ b/src/ims/element/static/field_reports.js
@@ -22,37 +22,16 @@ function initFieldReportsPage() {
         disableEditing();
         initFieldReportsTable();
 
-        let command = false;
-
-        function addFieldKeyDown() {
-            const keyCode = event.keyCode;
-
-            // 17 = control, 18 = option
-            if (keyCode === 17 || keyCode === 18) {
-                command = true;
+        function addFieldKeyUp(e) {
+            // holding alt/option or ctrl
+            if (e.altKey || e.ctrlKey) {
+                // 78 = n
+                if (e.keyCode === 78) {
+                    $("#new_field_report").click();
+                }
             }
-
-            // console.warn(keyCode);
         }
 
-        function addFieldKeyUp() {
-            const keyCode = event.keyCode;
-
-            // 17 = control, 18 = option
-            if (keyCode === 17 || keyCode === 18) {
-                command = false;
-                return;
-            }
-
-            // 78 = n
-            if (command && keyCode === 78) {
-                $("#new_field_report").click();
-            }
-
-            // if (command) { console.warn(keyCode); }
-        }
-
-        document.onkeydown = addFieldKeyDown;
         document.onkeyup   = addFieldKeyUp;
     }
 

--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -64,35 +64,16 @@ function initIncidentPage() {
 
         // Keyboard shortcuts
 
-        let command = false;
-
-        function addFieldKeyDown() {
-            const keyCode = event.keyCode;
-
-            // 17 = control, 18 = option
-            if (keyCode === 17 || keyCode === 18) {
-                command = true;
-            }
-
-            // console.warn(keyCode);
-        }
-
-        function addFieldKeyUp() {
-            const keyCode = event.keyCode;
-
-            // 17 = control, 18 = option
-            if (keyCode === 17 || keyCode === 18) {
-                command = false;
-                return;
-            }
-
-            // 13 = return
-            if (command && keyCode === 13) {
-                submitReportEntry();
+        function addFieldKeyUp(e) {
+            // holding alt/option or ctrl
+            if (e.altKey || e.ctrlKey) {
+                // 13 = return
+                if (e.keyCode === 13) {
+                    submitReportEntry();
+                }
             }
         }
 
-        $("#report_entry_add")[0].onkeydown = addFieldKeyDown;
         $("#report_entry_add")[0].onkeyup   = addFieldKeyUp;
     }
 

--- a/src/ims/element/static/incidents.js
+++ b/src/ims/element/static/incidents.js
@@ -22,37 +22,16 @@ function initIncidentsPage() {
         disableEditing();
         loadEventFieldReports(initIncidentsTable);
 
-        let command = false;
-
-        function addFieldKeyDown() {
-            const keyCode = event.keyCode;
-
-            // 17 = control, 18 = option
-            if (keyCode === 17 || keyCode === 18) {
-                command = true;
+        function addFieldKeyUp(e) {
+            // holding alt/option or ctrl
+            if (e.altKey || e.ctrlKey) {
+                // 78 = n
+                if (e.keyCode === 78) {
+                    $("#new_incident").click();
+                }
             }
-
-            // console.warn(keyCode);
         }
 
-        function addFieldKeyUp() {
-            const keyCode = event.keyCode;
-
-            // 17 = control, 18 = option
-            if (keyCode === 17 || keyCode === 18) {
-                command = false;
-                return;
-            }
-
-            // 78 = n
-            if (command && keyCode === 78) {
-                $("#new_incident").click();
-            }
-
-            // if (command) { console.warn(keyCode); }
-        }
-
-        document.onkeydown = addFieldKeyDown;
         document.onkeyup   = addFieldKeyUp;
     }
 


### PR DESCRIPTION
these properties tell you whether alt or ctrl was being pressed when the relevant mouse or keyboard event occurred

this change is a no-op, but it removes the need for that complex tracking of whether we're in a command mode or not

https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/ctrlKey https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/ctrlKey