### PR TITLE
stop using deprecated "keyCode", trigger hotkeys on keydown

### DIFF
--- a/src/ims/element/static/field_report.js
+++ b/src/ims/element/static/field_report.js
@@ -41,17 +41,13 @@ function initFieldReportPage() {
         disableEditing();
         loadAndDisplayFieldReport(loadedFieldReport);
 
-        function addFieldKeyUp(e) {
-            // holding alt/option or ctrl
-            if (e.altKey || e.ctrlKey) {
-                // 13 = return
-                if (e.keyCode === 13) {
-                    submitReportEntry();
-                }
+        function addFieldKeyDown(e) {
+            if (e.ctrlKey && e.key === "Enter") {
+                submitReportEntry();
             }
         }
 
-        $("#report_entry_add")[0].onkeyup   = addFieldKeyUp;
+        $("#report_entry_add")[0].onkeydown = addFieldKeyDown;
     }
 
     loadBody(loadedBody);

--- a/src/ims/element/static/field_reports.js
+++ b/src/ims/element/static/field_reports.js
@@ -22,17 +22,13 @@ function initFieldReportsPage() {
         disableEditing();
         initFieldReportsTable();
 
-        function addFieldKeyUp(e) {
-            // holding alt/option or ctrl
-            if (e.altKey || e.ctrlKey) {
-                // 78 = n
-                if (e.keyCode === 78) {
-                    $("#new_field_report").click();
-                }
+        function addFieldKeyDown(e) {
+            if (e.ctrlKey && e.key === "n") {
+                $("#new_field_report").click();
             }
         }
 
-        document.onkeyup   = addFieldKeyUp;
+        document.onkeydown = addFieldKeyDown;
     }
 
     loadBody(loadedBody);

--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -64,17 +64,13 @@ function initIncidentPage() {
 
         // Keyboard shortcuts
 
-        function addFieldKeyUp(e) {
-            // holding alt/option or ctrl
-            if (e.altKey || e.ctrlKey) {
-                // 13 = return
-                if (e.keyCode === 13) {
-                    submitReportEntry();
-                }
+        function addFieldKeyDown(e) {
+            if (e.ctrlKey && e.key === "Enter") {
+                submitReportEntry();
             }
         }
 
-        $("#report_entry_add")[0].onkeyup   = addFieldKeyUp;
+        $("#report_entry_add")[0].onkeydown = addFieldKeyDown;
     }
 
     loadBody(loadedBody);

--- a/src/ims/element/static/incidents.js
+++ b/src/ims/element/static/incidents.js
@@ -22,17 +22,13 @@ function initIncidentsPage() {
         disableEditing();
         loadEventFieldReports(initIncidentsTable);
 
-        function addFieldKeyUp(e) {
-            // holding alt/option or ctrl
-            if (e.altKey || e.ctrlKey) {
-                // 78 = n
-                if (e.keyCode === 78) {
-                    $("#new_incident").click();
-                }
+        function addFieldKeyDown(e) {
+            if (e.ctrlKey && e.key === "n") {
+                $("#new_incident").click();
             }
         }
 
-        document.onkeyup   = addFieldKeyUp;
+        document.onkeydown = addFieldKeyDown;
     }
 
     loadBody(loadedBody);


### PR DESCRIPTION
This moves us over to "key" rather than "keyCode". The latter is deprecated and slated for removal from web browsers...some time.

This change does remove the "alt" option and instead requires "ctrl". Presumably no one will care. That was needed because key doesn't work as simply as keyCode when alt is held down (you get a "Dead" back instead). I doubt anyone will notice this, and I want to enhance hotkeys after this anyway (and document them in the frontend).

Finally, this switches to keydown rather than keyup. The former is more natural.

https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode