### PR TITLE
add help modals to the four main pages

### DIFF
--- a/src/ims/element/incident/incident_template/template.xhtml
+++ b/src/ims/element/incident/incident_template/template.xhtml
@@ -5,6 +5,21 @@
     <p id="error_text"></p>
   </div>
 
+  <!-- Help modal for incident page -->
+  <div class="modal fade no-print" id="helpModal" tabindex="-1" aria-labelledby="helpModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <p class="modal-title fs-5" id="helpModalLabel">Keyboard shortcuts</p>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
+        </div>
+        <div class="modal-body">
+          <code>h</code>: toggle showing system-generated history <br/>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Incident number, state, priority -->
 
   <div class="row py-1">

--- a/src/ims/element/incident/incidents_template/template.xhtml
+++ b/src/ims/element/incident/incidents_template/template.xhtml
@@ -5,6 +5,23 @@
     <p id="error_text"></p>
   </div>
 
+  <!-- Help modal for incidents page -->
+  <div class="modal fade no-print" id="helpModal" tabindex="-1" aria-labelledby="helpModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <p class="modal-title fs-5" id="helpModalLabel">Keyboard shortcuts</p>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
+        </div>
+        <div class="modal-body">
+          <code>n</code>: create new incident <br/>
+          <code>a</code>: show all incidents <br/>
+          <code>/</code>: jump to search field <br/><br/>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <p class="no-print">
     <a href="../field_reports/">
       → Field Reports

--- a/src/ims/element/incident/report_template/template.xhtml
+++ b/src/ims/element/incident/report_template/template.xhtml
@@ -5,6 +5,21 @@
     <p id="error_text"></p>
   </div>
 
+  <!-- Help modal for field report page -->
+  <div class="modal fade no-print" id="helpModal" tabindex="-1" aria-labelledby="helpModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <p class="modal-title fs-5" id="helpModalLabel">Keyboard shortcuts</p>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
+        </div>
+        <div class="modal-body">
+          No keyboard shortcuts for this page...yet?<br/>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Identifiers -->
 
   <div class="row">

--- a/src/ims/element/incident/reports_template/template.xhtml
+++ b/src/ims/element/incident/reports_template/template.xhtml
@@ -5,6 +5,23 @@
     <p id="error_text"></p>
   </div>
 
+  <!-- Help modal for field reports page -->
+  <div class="modal fade no-print" id="helpModal" tabindex="-1" aria-labelledby="helpModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <p class="modal-title fs-5" id="helpModalLabel">Keyboard shortcuts</p>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
+        </div>
+        <div class="modal-body">
+          <code>n</code>: create new field report <br/>
+          <code>a</code>: show all field reports <br/>
+          <code>/</code>: jump to search field <br/><br/>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <p class="no-print">
     <a href="../incidents/">
       → Incidents

--- a/src/ims/element/static/field_report.js
+++ b/src/ims/element/static/field_report.js
@@ -41,6 +41,26 @@ function initFieldReportPage() {
         disableEditing();
         loadAndDisplayFieldReport(loadedFieldReport);
 
+        // Keyboard shortcuts
+        document.addEventListener("keydown", function(e) {
+            // No shortcuts when an input field is active
+            if (document.activeElement !== document.body) {
+                return;
+            }
+            // No shortcuts when ctrl, alt, or meta is being held down
+            if (e.altKey || e.ctrlKey || e.metaKey) {
+                return;
+            }
+            // ? --> show help modal
+            if (e.key === "?") {
+                $("#helpModal").modal("toggle");
+            }
+        });
+        document.getElementById("helpModal").addEventListener("keydown", function(e) {
+            if (e.key === "?") {
+                $("#helpModal").modal("toggle");
+            }
+        });
         $("#report_entry_add")[0].addEventListener("keydown", function (e) {
             if (e.ctrlKey && e.key === "Enter") {
                 submitReportEntry();

--- a/src/ims/element/static/field_reports.js
+++ b/src/ims/element/static/field_reports.js
@@ -32,6 +32,10 @@ function initFieldReportsPage() {
             if (e.altKey || e.ctrlKey || e.metaKey) {
                 return;
             }
+            // ? --> show help modal
+            if (e.key === "?") {
+                $("#helpModal").modal("toggle");
+            }
             // / --> jump to search box
             if (e.key === "/") {
                 // don't immediately input a "/" into the search box
@@ -48,6 +52,11 @@ function initFieldReportsPage() {
                 showRows(null);
             }
             // TODO: should there also be a shortcut to show the default filters?
+        });
+        document.getElementById("helpModal").addEventListener("keydown", function(e) {
+            if (e.key === "?") {
+                $("#helpModal").modal("toggle");
+            }
         });
     }
 

--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -72,9 +72,18 @@ function initIncidentPage() {
             if (e.altKey || e.ctrlKey || e.metaKey) {
                 return;
             }
+            // ? --> show help modal
+            if (e.key === "?") {
+                $("#helpModal").modal("toggle");
+            }
             // h --> toggle showing system entries
             if (e.key.toLowerCase() === "h") {
                 document.getElementById("history_checkbox").click();
+            }
+        });
+        document.getElementById("helpModal").addEventListener("keydown", function(e) {
+            if (e.key === "?") {
+                $("#helpModal").modal("toggle");
             }
         });
         $("#report_entry_add")[0].addEventListener("keydown", function (e) {

--- a/src/ims/element/static/incidents.js
+++ b/src/ims/element/static/incidents.js
@@ -32,6 +32,10 @@ function initIncidentsPage() {
             if (e.altKey || e.ctrlKey || e.metaKey) {
                 return;
             }
+            // ? --> show help modal
+            if (e.key === "?") {
+                $("#helpModal").modal("toggle");
+            }
             // / --> jump to search box
             if (e.key === "/") {
                 // don't immediately input a "/" into the search box
@@ -50,6 +54,12 @@ function initIncidentsPage() {
                 showType("all");
             }
             // TODO: should there also be a shortcut to show the default filters?
+        });
+
+        document.getElementById("helpModal").addEventListener("keydown", function(e) {
+            if (e.key === "?") {
+                $("#helpModal").modal("toggle");
+            }
         });
 
     }


### PR DESCRIPTION
Currently these just show the keyboard shortcuts for those pages. I may add some additional (non-shortcut) help text to each, and I may add a little "?" button in the right of the navbar to help users find this popup.

https://github.com/burningmantech/ranger-ims-server/issues/1482