### PR TITLE
have eventsource specify the relevant event for a message

### DIFF
--- a/src/ims/application/_eventsource.py
+++ b/src/ims/application/_eventsource.py
@@ -117,8 +117,10 @@ class DataStoreEventSourceLogObserver:
 
             if incident is None:
                 incidentNumber = loggerEvent.get("incidentNumber", None)
+                eventName = loggerEvent.get("eventID", "")
             else:
                 incidentNumber = incident.number
+                eventName = incident.eventID
 
             if incidentNumber is None:
                 self._log.critical(
@@ -127,7 +129,10 @@ class DataStoreEventSourceLogObserver:
                 )
                 return None
 
-            message = {"incident_number": incidentNumber}
+            message = {
+                "event_id": eventName,
+                "incident_number": incidentNumber,
+            }
 
         else:
             self._log.critical(

--- a/src/ims/element/static/field_reports.js
+++ b/src/ims/element/static/field_reports.js
@@ -85,7 +85,11 @@ function initFieldReportsTable() {
     requestEventSourceLock();
     const fieldReportChannel = new BroadcastChannel(fieldReportChannelName);
     fieldReportChannel.onmessage = function (e) {
-        const number = e.data;
+        const number = e.data["field_report_number"];
+        const event = e.data["event_id"]
+        if (event !== eventID) {
+            return;
+        }
         console.log("Got field report update: " + number);
         fieldReportsTable.ajax.reload(clearErrorMessage);
     }

--- a/src/ims/element/static/ims.js
+++ b/src/ims/element/static/ims.js
@@ -994,23 +994,15 @@ function subscribeToUpdates(closed) {
     }, true);
 
     eventSource.addEventListener("Incident", function(e) {
-        const jsonText = e.data;
-        const json = JSON.parse(jsonText);
-        const number = json["incident_number"];
-
         const send = new BroadcastChannel(incidentChannelName);
-        send.postMessage(number);
+        send.postMessage(JSON.parse(e.data));
     }, true);
 
     // TODO: this will never receive any events currently, since the server isn't configured to
     //  fire events for FieldReports. See
     //  https://github.com/burningmantech/ranger-ims-server/blob/954498eb125bb9a83d2b922361abef4935f228ba/src/ims/application/_eventsource.py#L113-L135
     eventSource.addEventListener("FieldReport", function(e) {
-        const jsonText = e.data;
-        const json = JSON.parse(jsonText);
-        const number = json["field_report_number"];
-
         const send = new BroadcastChannel(fieldReportChannelName);
-        send.postMessage(number);
+        send.postMessage(JSON.parse(e.data));
     }, true);
 }

--- a/src/ims/element/static/incidents.js
+++ b/src/ims/element/static/incidents.js
@@ -139,7 +139,11 @@ function initIncidentsTable() {
     requestEventSourceLock();
     const incidentChannel = new BroadcastChannel(incidentChannelName);
     incidentChannel.onmessage = function (e) {
-        const number = e.data;
+        const number = e.data["incident_number"];
+        const event = e.data["event_id"]
+        if (event !== eventID) {
+            return;
+        }
 
         // Now update/create the relevant row. This is a change from pre-2025, in that
         // we no longer reload all incidents here on any single incident update.


### PR DESCRIPTION
prior to this, the frontend would update the incidents page even if an incident change happened on a different event.

https://github.com/burningmantech/ranger-ims-server/issues/1488