### PR TITLE
change Field Reports sort order, tweak some logging

### DIFF
--- a/src/ims/element/static/field_reports.js
+++ b/src/ims/element/static/field_reports.js
@@ -187,7 +187,8 @@ function initDataTables() {
             },
         ],
         "order": [
-            [1, "asc"],
+            // creation time descending
+            [1, "dsc"],
         ],
         "createdRow": function (row, fieldReport, index) {
             $(row).click(function () {

--- a/src/ims/element/static/incidents.js
+++ b/src/ims/element/static/incidents.js
@@ -152,13 +152,13 @@ function initIncidentsTable() {
             incidentsTable.rows().every( function () {
                 const existingIncident = this.data();
                 if (existingIncident.number === number) {
-                    console.log("Updating incident " + number);
+                    console.log("Updating Incident " + number);
                     this.data(updatedIncident);
                     done = true;
                 }
             });
             if (!done) {
-                console.log("Adding new incident " + number);
+                console.log("Loading new Incident " + number);
                 incidentsTable.row.add(updatedIncident);
             }
             clearErrorMessage();
@@ -166,7 +166,7 @@ function initIncidentsTable() {
         }
 
         function updateError(error) {
-            const message = "Failed to update incident " + number + ": " + error;
+            const message = "Failed to update Incident " + number + ": " + error;
             console.error(message);
             setErrorMessage(message);
         }


### PR DESCRIPTION
the Field Reports page was previously sorted by default by creation time ascending. It's more natural to see this page sorted by creation time descending, and that matches with how we sort the Incidents page.