### PR TITLE
add some resiliency around missed SSEs

### DIFF
--- a/src/ims/application/_eventsource.py
+++ b/src/ims/application/_eventsource.py
@@ -184,10 +184,14 @@ class DataStoreEventSourceLogObserver:
         """
         See L{ILogObserver.__call__}.
         """
-        self._counter[0] += 1
 
         eventSourceEvent = self._transmogrify(event, self._counter[0])
         if eventSourceEvent is None:
             return
 
+        # The counter is used for the IDs for EventSource events. Consumers of the
+        # EventSource can rely on the counter increasing each time, without gaps,
+        # through the natural numbers. This lets them detect if they've missed an
+        # event along the way.
+        self._counter[0] += 1
         self._publish(eventSourceEvent, self._counter[0])

--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -56,10 +56,9 @@ function initIncidentPage() {
         incidentChannel.onmessage = function (e) {
             const number = e.data["incident_number"];
             const event = e.data["event_id"]
-            if (event !== eventID) {
-                return;
-            }
-            if (number === incidentNumber) {
+            const missedUpdate = e.data["missed_update"];
+
+            if (missedUpdate || (event === eventID && number === incidentNumber)) {
                 console.log("Got incident update: " + number);
                 loadAndDisplayIncident();
                 loadAndDisplayFieldReports();

--- a/src/ims/element/static/incidents.js
+++ b/src/ims/element/static/incidents.js
@@ -139,6 +139,12 @@ function initIncidentsTable() {
     requestEventSourceLock();
     const incidentChannel = new BroadcastChannel(incidentChannelName);
     incidentChannel.onmessage = function (e) {
+        if (e.data["missed_update"]) {
+            console.log("Reloading the whole table to be cautious, as an SSE was missed")
+            incidentsTable.ajax.reload(clearErrorMessage);
+            return;
+        }
+
         const number = e.data["incident_number"];
         const event = e.data["event_id"]
         if (event !== eventID) {


### PR DESCRIPTION
with my changes yesterday to only selectively update the Incidents page, i.e. only update one row at a time, it's even more important that we don't miss any SSEs. This change builds in some resiliency, by having the Incidents and Incident pages do more substantial reloads when an SSE is known to have been missed.

I'm not sure this is the final version of what I want in prod on playa, but I'd like to try this out in staging, where the network connection is less reliable for me than from localhost.

https://github.com/burningmantech/ranger-ims-server/issues/1488