### PR TITLE
improve handling for potentially missed SSEs

### DIFF
--- a/src/ims/application/_api.py
+++ b/src/ims/application/_api.py
@@ -1111,6 +1111,9 @@ class APIApplication:
         """
         self._log.debug("Event source connected: {id}", id=id(request))
 
+        # Note that we don't read the Last-Event-Id header, which browsers provide
+        # on automated reconnection. We don't need it.
+
         # Clear the cookies on the response. Without this here, the eventsource
         # call will often return Set-Cookie values that lead clients to stomp
         # over authenticated session cookies with unauthenticated ones.

--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -56,9 +56,9 @@ function initIncidentPage() {
         incidentChannel.onmessage = function (e) {
             const number = e.data["incident_number"];
             const event = e.data["event_id"]
-            const missedUpdate = e.data["missed_update"];
+            const updateAll = e.data["update_all"];
 
-            if (missedUpdate || (event === eventID && number === incidentNumber)) {
+            if (updateAll || (event === eventID && number === incidentNumber)) {
                 console.log("Got incident update: " + number);
                 loadAndDisplayIncident();
                 loadAndDisplayFieldReports();

--- a/src/ims/element/static/incidents.js
+++ b/src/ims/element/static/incidents.js
@@ -139,7 +139,7 @@ function initIncidentsTable() {
     requestEventSourceLock();
     const incidentChannel = new BroadcastChannel(incidentChannelName);
     incidentChannel.onmessage = function (e) {
-        if (e.data["missed_update"]) {
+        if (e.data["update_all"]) {
             console.log("Reloading the whole table to be cautious, as an SSE was missed")
             incidentsTable.ajax.reload(clearErrorMessage);
             return;
@@ -168,6 +168,7 @@ function initIncidentsTable() {
                 incidentsTable.row.add(updatedIncident);
             }
             clearErrorMessage();
+            incidentsTable.processing(false);
             incidentsTable.draw();
         }
 


### PR DESCRIPTION
This starts telling EventSource clients, upon connection, which SSE ID was the most recently published. That allows the client to know whether it should reload its data pages to be in sync with the server. I store the previous SSE ID in LocalStorage, so that all tabs can share that value together.

This makes the synchronization mechanism very resilient to the EventSource connection needing to be reestablished.

This simplifies some of the _eventsource.py code by removing unused code around replaying events (we were never using that).