### PR TITLE
add ability to strike/unstrike Field Report report entries

### DIFF
--- a/src/ims/config/_urls.py
+++ b/src/ims/config/_urls.py
@@ -54,11 +54,14 @@ class URLs:
     event: ClassVar[URL] = events.child("<event_id>").child("")
     incidents: ClassVar[URL] = event.child("incidents").child("")
     incidentNumber: ClassVar[URL] = incidents.child("<incident_number>")
-    fieldReports: ClassVar[URL] = event.child("field_reports").child("")
-    fieldReport: ClassVar[URL] = fieldReports.child("<field_report_number>")
-
     incident_reportEntries: ClassVar[URL] = incidentNumber.child("report_entries")
     incident_reportEntry: ClassVar[URL] = incident_reportEntries.child(
+        "<report_entry_id>"
+    )
+    fieldReports: ClassVar[URL] = event.child("field_reports").child("")
+    fieldReport: ClassVar[URL] = fieldReports.child("<field_report_number>")
+    fieldReport_reportEntries: ClassVar[URL] = fieldReport.child("report_entries")
+    fieldReport_reportEntry: ClassVar[URL] = fieldReport_reportEntries.child(
         "<report_entry_id>"
     )
 

--- a/src/ims/element/incident/report_template/template.xhtml
+++ b/src/ims/element/incident/report_template/template.xhtml
@@ -15,6 +15,7 @@
         </div>
         <div class="modal-body">
           <code>n</code>: create new Field Report <br/>
+          <code>h</code>: toggle showing system-generated history <br/>
         </div>
       </div>
     </div>
@@ -133,6 +134,10 @@
       <div class="card">
         <label class="control-label card-header">Details</label>
         <div id="report_entry_well" class="card-body">
+          <label class="control-label">
+            <input id="history_checkbox" type="checkbox" onchange="toggleShowHistory()"/>
+            Show history and stricken
+          </label>
           <div id="report_entries"/>
           <div class="card-footer">
             <textarea

--- a/src/ims/element/static/field_report.js
+++ b/src/ims/element/static/field_report.js
@@ -23,10 +23,6 @@ function initFieldReportPage() {
         // for a new field report
         if (fieldReport.number == null) {
             $("#field_report_summary").focus();
-        } else {
-            // Scroll to report_entry_add field
-            $("html, body").animate({scrollTop: $("#report_entry_add").offset().top}, 500);
-            $("#report_entry_add").focus();
         }
 
         // Warn the user if they're about to navigate away with unsaved text.
@@ -55,6 +51,10 @@ function initFieldReportPage() {
             if (e.key === "?") {
                 $("#helpModal").modal("toggle");
             }
+            // h --> toggle showing system entries
+            if (e.key.toLowerCase() === "h") {
+                document.getElementById("history_checkbox").click();
+            }
             // n --> new field report
             if (e.key.toLowerCase() === "n") {
                 window.open("./new", '_blank').focus();
@@ -66,7 +66,7 @@ function initFieldReportPage() {
             }
         });
         $("#report_entry_add")[0].addEventListener("keydown", function (e) {
-            if (e.ctrlKey && e.key === "Enter") {
+            if ((e.ctrlKey || e.altKey) && e.key === "Enter") {
                 submitReportEntry();
             }
         });
@@ -142,6 +142,7 @@ function loadAndDisplayFieldReport(success) {
         drawNumber();
         drawIncident();
         drawSummary();
+        toggleShowHistory();
         drawReportEntries(fieldReport.report_entries);
         clearErrorMessage();
 

--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -94,7 +94,7 @@ function initIncidentPage() {
             }
         });
         $("#report_entry_add")[0].addEventListener("keydown", function (e) {
-            if (e.ctrlKey && e.key === "Enter") {
+            if ((e.ctrlKey || e.altKey) && e.key === "Enter") {
                 submitReportEntry();
             }
         });
@@ -697,19 +697,6 @@ function drawLocationDescription() {
         $("#incident_location_description")
             .val(incident.location.description)
             ;
-    }
-}
-
-
-//
-// Incident generated history display
-//
-
-function toggleShowHistory() {
-    if ($("#history_checkbox").is(":checked")) {
-        $("#report_entries").removeClass("hide-history");
-    } else {
-        $("#report_entries").addClass("hide-history");
     }
 }
 

--- a/src/ims/store/_abc.py
+++ b/src/ims/store/_abc.py
@@ -317,7 +317,7 @@ class IMSDataStore(ABC):
         """
 
     @abstractmethod
-    async def setReportEntry_stricken(
+    async def setIncidentReportEntry_stricken(
         self,
         eventID: str,
         incidentNumber: int,
@@ -326,7 +326,7 @@ class IMSDataStore(ABC):
         author: str,
     ) -> None:
         """
-        Set the stricken value for the given report entry ID.
+        Set the stricken value for the given report entry ID on an incident.
         """
 
     ###
@@ -434,4 +434,17 @@ class IMSDataStore(ABC):
         """
         Detach the field report with the given number from the incident with
         the given number in the given event.
+        """
+
+    @abstractmethod
+    async def setFieldReportReportEntry_stricken(
+        self,
+        eventID: str,
+        fieldReportNumber: int,
+        reportEntryID: int,
+        stricken: bool,
+        author: str,
+    ) -> None:
+        """
+        Set the stricken value for the given report entry ID on a field report.
         """

--- a/src/ims/store/mysql/_queries.py
+++ b/src/ims/store/mysql/_queries.py
@@ -506,7 +506,7 @@ queries = Queries(
             INCIDENT_NUMBER = %(incidentNumber)s
         """,
     ),
-    setReportEntry_stricken=Query(
+    setIncidentReportEntry_stricken=Query(
         "set the stricken value on a report entry",
         # This query seems bloated on first blush, because the whole "where ID in (..."
         # could just be "where ID =". What it's doing though is ensuring that the
@@ -521,6 +521,25 @@ queries = Queries(
             where
                 EVENT = ({query_eventID}) and
                 INCIDENT_NUMBER = %(incidentNumber)s and
+                REPORT_ENTRY = %(reportEntryID)s
+        )
+        """,
+    ),
+    setFieldReportReportEntry_stricken=Query(
+        "set the stricken value on a field report's report entry",
+        # This query seems bloated on first blush, because the whole "where ID in (..."
+        # could just be "where ID =". What it's doing though is ensuring that the
+        # provided eventID and fieldReportNumber actually align with the reportEntryID
+        # in question, and that's important for authorization purposes.
+        f"""
+        update REPORT_ENTRY
+        set STRICKEN = %(stricken)s
+        where ID IN (
+            select REPORT_ENTRY
+            from FIELD_REPORT__REPORT_ENTRY
+            where
+                EVENT = ({query_eventID}) and
+                FIELD_REPORT_NUMBER = %(fieldReportNumber)s and
                 REPORT_ENTRY = %(reportEntryID)s
         )
         """,

--- a/src/ims/store/sqlite/_queries.py
+++ b/src/ims/store/sqlite/_queries.py
@@ -496,8 +496,8 @@ queries = Queries(
         where EVENT = ({query_eventID}) and INCIDENT_NUMBER = :incidentNumber
         """,
     ),
-    setReportEntry_stricken=Query(
-        "set the stricken value on a report entry",
+    setIncidentReportEntry_stricken=Query(
+        "set the stricken value on an incident's report entry",
         # This query seems bloated on first blush, because the whole "where ID in (..."
         # could just be "where ID =". What it's doing though is ensuring that the
         # provided eventID and incidentNumber actually align with the reportEntryID
@@ -511,6 +511,25 @@ queries = Queries(
             where
                 EVENT = ({query_eventID}) and
                 INCIDENT_NUMBER = :incidentNumber and
+                REPORT_ENTRY = :reportEntryID
+        )
+        """,
+    ),
+    setFieldReportReportEntry_stricken=Query(
+        "set the stricken value on a field report's report entry",
+        # This query seems bloated on first blush, because the whole "where ID in (..."
+        # could just be "where ID =". What it's doing though is ensuring that the
+        # provided eventID and fieldReportNumber actually align with the reportEntryID
+        # in question, and that's important for authorization purposes.
+        f"""
+        update REPORT_ENTRY
+        set STRICKEN = :stricken
+        where ID IN (
+            select REPORT_ENTRY
+            from FIELD_REPORT__REPORT_ENTRY
+            where
+                EVENT = ({query_eventID}) and
+                FIELD_REPORT_NUMBER = :fieldReportNumber and
                 REPORT_ENTRY = :reportEntryID
         )
         """,

--- a/src/ims/store/test/incident.py
+++ b/src/ims/store/test/incident.py
@@ -770,7 +770,7 @@ class DataStoreIncidentTests(DataStoreTests):
             self.fail("StorageError not raised")
 
     @asyncAsDeferred
-    async def test_setReportEntry_stricken(self) -> None:
+    async def test_setIncidentReportEntry_stricken(self) -> None:
         incident = anIncident1
         reportEntries = (aReportEntry,)
 
@@ -797,7 +797,7 @@ class DataStoreIncidentTests(DataStoreTests):
         self.assertFalse(updatedEntry.stricken)
 
         # Strike the report entry, then check that it's stricken
-        await store.setReportEntry_stricken(
+        await store.setIncidentReportEntry_stricken(
             incident.eventID, incident.number, entryToStrike, True, "Mr. Striker"
         )
         updatedIncident = await store.incidentWithNumber(
@@ -809,7 +809,7 @@ class DataStoreIncidentTests(DataStoreTests):
         self.assertTrue(updatedEntry.stricken)
 
         # Unstrike the report entry, then check it's not stricken
-        await store.setReportEntry_stricken(
+        await store.setIncidentReportEntry_stricken(
             incident.eventID, incident.number, entryToStrike, False, "Mr. Striker"
         )
         updatedIncident = await store.incidentWithNumber(
@@ -821,7 +821,7 @@ class DataStoreIncidentTests(DataStoreTests):
         self.assertFalse(updatedEntry.stricken)
 
     @asyncAsDeferred
-    async def test_setReportEntry_stricken_error(self) -> None:
+    async def test_setIncidentReportEntry_stricken_error(self) -> None:
         """
         :meth:`IMSDataStore.setReportEntry_stricken` raises
         :exc:`StorageError` when the store raises an exception.
@@ -853,7 +853,7 @@ class DataStoreIncidentTests(DataStoreTests):
         # Conveniently, this test enforces that the incident number must be
         # correctly specified by the caller.
         try:
-            await store.setReportEntry_stricken(
+            await store.setIncidentReportEntry_stricken(
                 incident.eventID,
                 incident.number + 1,
                 entryToStrike,


### PR DESCRIPTION
this lets the user strike/unstrike from both the Incident page and the Field Report page.

This adds a "show history" checkbox to the FR page, as we already had for the Incident page.
This also brings back option+enter for submitting report entries (something very useful on OSX, which I removed recently).

https://github.com/burningmantech/ranger-ims-server/issues/249