### PR TITLE
remove confusing messaging from login screen for already-logged-in user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,12 @@ Each month below should look like the following, using the same ordering for the
 
 ### Added
 
+- Introduced "striking" of report entries. This allows a user to hide an outdated/inaccurate entry, such that it doesn't appear by default on the Incident or Field Report page. https://github.com/burningmantech/ranger-ims-server/issues/249
 - Added help modals, toggled by pressing "?", which show keyboard shortcuts for the current page. https://github.com/burningmantech/ranger-ims-server/issues/1482
+
+### Fixed
+
+- Removed confusing messaging from login screen when a user was already logged in. https://github.com/burningmantech/ranger-ims-server/pull/1511 https://github.com/burningmantech/ranger-ims-server/issues/1508
 
 ## 2024-12
 

--- a/src/ims/element/login/_login.py
+++ b/src/ims/element/login/_login.py
@@ -46,21 +46,3 @@ class LoginPage(Page):
         if self.failed:
             return tag
         return ""
-
-    @renderer
-    def if_authz_failed(self, request: IRequest, tag: Tag) -> KleinRenderable:
-        """
-        Render conditionally if the user failed to authorize.
-        """
-        if self.failed:
-            # authn failed, not authz
-            return ""
-
-        session = request.getSession()
-        user = getattr(session, "user", None)
-
-        if user is None:
-            return ""
-
-        # We have a user but still got sent to login page
-        return tag

--- a/src/ims/element/login/template.xhtml
+++ b/src/ims/element/login/template.xhtml
@@ -8,7 +8,7 @@
   <form method="POST" id="login_form" class="form-horizontal">
 
     <button t:render="if_authn_failed" type="button" class="btn btn-block btn-danger">Authentication Failed</button>
-    <button t:render="if_authz_failed" type="button" class="btn btn-block btn-danger">Authorization Failed for <code
+    <button t:render="if_logged_in" type="button" class="btn btn-block btn-danger">You are already logged in as <span
             t:render="logged_in_user"/></button>
 
     <p>


### PR DESCRIPTION
this "if_authz_failed" tag must've been a relic from the past, because in the current model, if you're authenticated, it doesn't really make sense to ask if you're generally "authorized". You can only be authorized in relation to a particular page or permission.

https://github.com/burningmantech/ranger-ims-server/issues/1508