### PR TITLE
make a few frontend style tweaks

### DIFF
--- a/src/ims/element/incident/incident/template.xhtml
+++ b/src/ims/element/incident/incident/template.xhtml
@@ -7,15 +7,15 @@
 
 <script>
   <!-- FIXME: figure out how to move this to / include from incident.js -->
-  var editingAllowed              = <json t:render="editing_allowed"/>;
-  var eventID                     = <json t:render="event_id"/>;
-  var incidentNumber              = <json t:render="incident_number"/>;
+  const editingAllowed            = <json t:render="editing_allowed"/>;
+  const eventID                   = <json t:render="event_id"/>;
+  let incidentNumber              = <json t:render="incident_number"/>;
 
-  var pageTemplateURL             = url_viewIncidentTemplate;
-  var incidentsURL                = urlReplace(url_incidents);
-  var viewIncidentsURL            = urlReplace(url_viewIncidents);
+  const pageTemplateURL           = url_viewIncidentTemplate;
+  const incidentsURL              = urlReplace(url_incidents);
+  const viewIncidentsURL          = urlReplace(url_viewIncidents);
 
-  var concentricStreetNameByID    = <json t:render="concentric_street_name_by_id"/>;
+  const concentricStreetNameByID  = <json t:render="concentric_street_name_by_id"/>;
 
   initIncidentPage();
 </script>

--- a/src/ims/element/incident/incidents/template.xhtml
+++ b/src/ims/element/incident/incidents/template.xhtml
@@ -6,16 +6,16 @@
 
 <script>
   <!-- FIXME: figure out how to move this to / include from incident.js -->
-  var editingAllowed            = <json t:render="editing_allowed"/>;
-  var eventID                   = <json t:render="event_id"/>;
+  const editingAllowed            = <json t:render="editing_allowed"/>;
+  const eventID                   = <json t:render="event_id"/>;
 
-  var pageTemplateURL           = url_viewIncidentsTemplate;
-  var dataURL                   = urlReplace(url_incidents + "?exclude_system_entries=true");
-  var viewIncidentsURL          = urlReplace(url_viewIncidents);
-  var viewFieldReportsURL       = urlReplace(url_viewFieldReports);
+  const pageTemplateURL           = url_viewIncidentsTemplate;
+  const dataURL                   = urlReplace(url_incidents + "?exclude_system_entries=true");
+  const viewIncidentsURL          = urlReplace(url_viewIncidents);
+  const viewFieldReportsURL       = urlReplace(url_viewFieldReports);
 
-  var concentricStreetNameByID  = <json t:render="concentric_street_name_by_id"/>;
-  const allIncidentTypes        = <json t:render="incident_types"/>;
+  const concentricStreetNameByID  = <json t:render="concentric_street_name_by_id"/>;
+  const allIncidentTypes          = <json t:render="incident_types"/>;
 
   initIncidentsPage();
 </script>

--- a/src/ims/element/incident/report/template.xhtml
+++ b/src/ims/element/incident/report/template.xhtml
@@ -7,11 +7,11 @@
 
 <script>
   <!-- FIXME: figure out how to move this to / include from report.js -->
-  var editingAllowed        = <json t:render="editing_allowed"/>;
-  var eventID               = <json t:render="event_id"/>;
-  var fieldReportNumber     = <json t:render="field_report_number"/>;
-  var canWriteIncidents     = <json t:render="can_write_incidents"/>;
-  var pageTemplateURL       = url_viewFieldReportTemplate;
+  const editingAllowed      = <json t:render="editing_allowed"/>;
+  const eventID             = <json t:render="event_id"/>;
+  const canWriteIncidents   = <json t:render="can_write_incidents"/>;
+  const pageTemplateURL     = url_viewFieldReportTemplate;
+  let fieldReportNumber     = <json t:render="field_report_number"/>;
 
   initFieldReportPage();
 </script>

--- a/src/ims/element/incident/reports/template.xhtml
+++ b/src/ims/element/incident/reports/template.xhtml
@@ -5,10 +5,10 @@
 <body/>
 
 <script>
-  var pageTemplateURL   = url_viewFieldReportsTemplate;
-  var editingAllowed    = <json t:render="editing_allowed"/>;
-  var eventID           = <json t:render="event_id"/>;
-  var viewIncidentsURL  = urlReplace(url_viewIncidents);
+  const pageTemplateURL   = url_viewFieldReportsTemplate;
+  const editingAllowed    = <json t:render="editing_allowed"/>;
+  const eventID           = <json t:render="event_id"/>;
+  const viewIncidentsURL  = urlReplace(url_viewIncidents);
 
   initFieldReportsPage();
 </script>

--- a/src/ims/element/incident/reports_template/template.xhtml
+++ b/src/ims/element/incident/reports_template/template.xhtml
@@ -49,6 +49,7 @@
       <button
               id="show_days"
               type="button"
+              title="Filter by last modified date"
               class="btn btn-light btn-sm dropdown-toggle"
               data-bs-toggle="dropdown"
       >

--- a/src/ims/element/static/field_report.js
+++ b/src/ims/element/static/field_report.js
@@ -278,8 +278,8 @@ function sendEdits(edits, success, error) {
                 return;
             }
 
-            // Store the new number in our incident object
-            fieldReport.number = newNumber;
+            // Store the new number in our field report object
+            fieldReportNumber = fieldReport.number = newNumber;
 
             // Update browser history to update URL
             drawTitle();
@@ -357,4 +357,11 @@ function makeIncident() {
         "ranger_handles": authors,
         }, createOk, createFail,
     );
+}
+
+
+// The success callback for a report entry strike call.
+function onStrikeSuccess() {
+    loadAndDisplayFieldReport();
+    clearErrorMessage();
 }

--- a/src/ims/element/static/ims.js
+++ b/src/ims/element/static/ims.js
@@ -897,22 +897,6 @@ function reportEntryEdited() {
     }
 }
 
-// The success callback for a report entry strike call.
-// This function is designed to work from either the incident
-// or the field report page.
-function onStrikeSuccess() {
-    if (typeof loadAndDisplayFieldReport !== "undefined") {
-        loadAndDisplayFieldReport();
-    }
-    if (typeof loadAndDisplayIncident !== "undefined") {
-        loadAndDisplayIncident();
-    }
-    if (typeof loadAndDisplayFieldReports !== "undefined") {
-        loadAndDisplayFieldReports();
-    }
-    clearErrorMessage();
-}
-
 // The error callback for a report entry strike call.
 // This function is designed to work from either the incident
 // or the field report page.

--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -186,8 +186,7 @@ function loadAndDisplayIncident(success) {
 
 
 function loadAndDisplayFieldReports() {
-    loadUnattachedFieldReports(function () {
-        drawMergedReportEntries();
+    loadAllFieldReports(function () {
         drawFieldReportsToAttach();
     });
     loadAttachedFieldReports(function () {
@@ -330,27 +329,27 @@ function localLoadIncidentTypes() {
 
 
 //
-// Load unattached field reports
+// Load all field reports
 //
 
-let unattachedFieldReports = null;
+let allFieldReports = null;
 
-function loadUnattachedFieldReports(success) {
-    if (unattachedFieldReports === undefined) {
+function loadAllFieldReports(success) {
+    if (allFieldReports === undefined) {
         return;
     }
 
     function ok(data, status, xhr) {
-        const _unattachedFieldReports = [];
+        const _allFieldReports = [];
         for (const d of data) {
-            _unattachedFieldReports.push(d);
+            _allFieldReports.push(d);
         }
         // apply a descending sort based on the field report number,
         // being cautious about field report number being null
-        _unattachedFieldReports.sort(function (a, b) {
+        _allFieldReports.sort(function (a, b) {
             return (b.number ?? -1) - (a.number ?? -1);
         })
-        unattachedFieldReports = _unattachedFieldReports;
+        allFieldReports = _allFieldReports;
 
         if (success) {
             success();
@@ -360,9 +359,9 @@ function loadUnattachedFieldReports(success) {
     function fail(error, status, xhr) {
         if (xhr.status === 403) {
             // We're not allowed to look these up.
-            unattachedFieldReports = undefined;
+            allFieldReports = undefined;
         } else {
-            const message = "Failed to load unattached field reports";
+            const message = "Failed to load field reports";
             console.error(message + ": " + error);
             setErrorMessage(message);
         }
@@ -766,12 +765,12 @@ function drawFieldReportsToAttach() {
     select.empty();
     select.append($("<option />"));
 
-    if (!unattachedFieldReports) {
+    if (!allFieldReports) {
         container.addClass("hidden");
     } else {
 
         select.append($("<optgroup label=\"Unattached to any incident\">"));
-        for (const report of unattachedFieldReports) {
+        for (const report of allFieldReports) {
             // Skip field reports that *are* attached to an incident
             if (report.incident != null) {
                 continue;
@@ -785,7 +784,7 @@ function drawFieldReportsToAttach() {
         select.append($("</optgroup>"));
 
         select.append($("<optgroup label=\"Attached to another incident\">"));
-        for (const report of unattachedFieldReports) {
+        for (const report of allFieldReports) {
             // Skip field reports that *are not* attached to an incident
             if (report.incident == null) {
                 continue;
@@ -1144,4 +1143,12 @@ function attachFieldReport() {
     );
 
     jsonRequest(url, {}, ok, fail);
+}
+
+
+// The success callback for a report entry strike call.
+function onStrikeSuccess() {
+    loadAndDisplayIncident();
+    loadAndDisplayFieldReports();
+    clearErrorMessage();
 }


### PR DESCRIPTION
* "unttachedFieldReports" was misleading, because it included all field reports, including those attached to the current incident
* we can use const rather than var in many places
* title for "show days" is helpful to clarify it's about modification date, not creation date
* no need for an additional drawMergedReportEntries call
* split onStrikeSuccess into incident and field report versions, to get rid of the nasty "typeof ... !== 'undefined'" hack