### PR TITLE
add Subresource Integrity checks for external JS scripts

### DIFF
--- a/src/ims/application/_external.py
+++ b/src/ims/application/_external.py
@@ -670,40 +670,6 @@ class ExternalApplication:
 
     config: Configuration
 
-    bootstrapVersionNumber = "5.3.3"
-    jqueryVersionNumber = "3.1.0"
-    dataTablesVersionNumber = "2.1.8"
-    lscacheVersionNumber = "1.0.5"
-
-    bootstrapVersion = f"bootstrap-{bootstrapVersionNumber}-dist"
-    jqueryVersion = f"jquery-{jqueryVersionNumber}"
-    dataTablesVersion = f"DataTables-{dataTablesVersionNumber}"
-    lscacheVersion = f"lscache-{lscacheVersionNumber}"
-
-    bootstrapSourceURL = URL.fromText(
-        f"https://github.com/twbs/bootstrap/releases/download/"
-        f"v{bootstrapVersionNumber}/{bootstrapVersion}.zip"
-    )
-
-    jqueryJSSourceURL = URL.fromText(
-        f"https://cdnjs.cloudflare.com/ajax/libs/jquery/"
-        f"{jqueryVersionNumber}/jquery.min.js"
-    )
-
-    jqueryMapSourceURL = URL.fromText(
-        f"https://cdnjs.cloudflare.com/ajax/libs/jquery/"
-        f"{jqueryVersionNumber}/jquery.min.map"
-    )
-
-    dataTablesSourceURL = URL.fromText(
-        f"https://datatables.net/releases/DataTables-{dataTablesVersionNumber}.zip"
-    )
-
-    lscacheJSSourceURL = URL.fromText(
-        f"https://raw.githubusercontent.com/pamelafox/lscache/"
-        f"{lscacheVersionNumber}/lscache.min.js"
-    )
-
     @router.route(_unprefix(URLs.bootstrapBase), methods=("HEAD", "GET"), branch=True)
     @static
     async def bootstrapResource(self, request: IRequest) -> KleinRenderable:
@@ -718,9 +684,9 @@ class ExternalApplication:
         request.setHeader(HeaderName.contentType.value, ContentType.css.value)
         return await self.cachedZippedResource(
             request,
-            self.bootstrapSourceURL,
-            self.bootstrapVersion,
-            self.bootstrapVersion,
+            self.config.externalDeps.bootstrapSourceURL,
+            self.config.externalDeps.bootstrapVersion,
+            self.config.externalDeps.bootstrapVersion,
             *names,
         )
 
@@ -732,7 +698,9 @@ class ExternalApplication:
         """
         request.setHeader(HeaderName.contentType.value, ContentType.javascript.value)
         return await self.cachedResource(
-            request, self.jqueryJSSourceURL, f"{self.jqueryVersion}.min.js"
+            request,
+            self.config.externalDeps.jqueryJSSourceURL,
+            f"{self.config.externalDeps.jqueryVersion}.min.js",
         )
 
     @router.route(_unprefix(URLs.jqueryMap), methods=("HEAD", "GET"))
@@ -743,7 +711,9 @@ class ExternalApplication:
         """
         request.setHeader(HeaderName.contentType.value, ContentType.json.value)
         return await self.cachedResource(
-            request, self.jqueryMapSourceURL, f"{self.jqueryVersion}.min.map"
+            request,
+            self.config.externalDeps.jqueryMapSourceURL,
+            f"{self.config.externalDeps.jqueryVersion}.min.map",
         )
 
     @router.route(_unprefix(URLs.dataTablesBase), methods=("HEAD", "GET"), branch=True)
@@ -772,9 +742,9 @@ class ExternalApplication:
                 Path(__file__).parent.parent
                 / "element"
                 / "static"
-                / f"DataTables-{self.dataTablesVersionNumber}.zip"
+                / f"DataTables-{self.config.externalDeps.dataTablesVersionNumber}.zip"
             ),
-            self.dataTablesVersion,
+            self.config.externalDeps.dataTablesVersion,
             *names,
         )
 
@@ -786,7 +756,9 @@ class ExternalApplication:
         """
         request.setHeader(HeaderName.contentType.value, ContentType.javascript.value)
         return await self.cachedResource(
-            request, self.lscacheJSSourceURL, f"{self.lscacheVersion}.min.js"
+            request,
+            self.config.externalDeps.lscacheJSSourceURL,
+            f"{self.config.externalDeps.lscacheVersion}.min.js",
         )
 
     async def cacheFromURL(self, url: URL, name: str) -> Path:

--- a/src/ims/config/__init__.py
+++ b/src/ims/config/__init__.py
@@ -19,12 +19,14 @@ Incident Management System configuration.
 """
 
 from ._config import Configuration, ConfigurationError, LogFormat
+from ._external_deps import ExternalDeps
 from ._urls import URLs
 
 
 __all__ = (
     "Configuration",
     "ConfigurationError",
+    "ExternalDeps",
     "LogFormat",
     "URLs",
 )

--- a/src/ims/config/_config.py
+++ b/src/ims/config/_config.py
@@ -39,6 +39,7 @@ from ims.store import IMSDataStore
 from ims.store.mysql import DataStore as MySQLDataStore
 from ims.store.sqlite import DataStore as SQLiteDataStore
 
+from ._external_deps import ExternalDeps
 from ._urls import URLs
 
 
@@ -167,6 +168,7 @@ class Configuration:
 
     _log: ClassVar[Logger] = Logger()
     urls: ClassVar = URLs
+    externalDeps: ClassVar = ExternalDeps
 
     @mutable(kw_only=True, eq=False)
     class _State:

--- a/src/ims/config/_external_deps.py
+++ b/src/ims/config/_external_deps.py
@@ -1,0 +1,70 @@
+##
+# See the file COPYRIGHT for copyright information.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##
+
+"""
+Incident Management System external dependency versions.
+"""
+
+from attrs import frozen
+from hyperlink import URL
+
+
+__all__ = ()
+
+
+@frozen(kw_only=True)
+class ExternalDeps:
+    bootstrapVersionNumber = "5.3.3"
+    bootstrapJsIntegrity = "sha512-7Pi/otdlbbCR+LnW+F7PwFcSDJOuUJB3OxtEHbg4vSMvzvJjde4Po1v4BR9Gdc9aXNUNFVUY+SK51wWT8WF0Gg=="  # noqa: E501
+
+    jqueryVersionNumber = "3.1.0"
+    jqueryJsIntegrity = "sha512-qzrZqY/kMVCEYeu/gCm8U2800Wz++LTGK4pitW/iswpCbjwxhsmUwleL1YXaHImptCHG0vJwU7Ly7ROw3ZQoww=="  # noqa: E501
+
+    dataTablesVersionNumber = "2.1.8"
+    dataTablesJsIntegrity = "sha512-aB+KD1UH6xhwz0ZLqIGK+if/B83XzgnFzDJtf195axOEqurA7ahWCpl8wgXWVfcMslhnmYigAjYXShrJSlxgWg=="  # noqa: E501
+    dataTablesBootstrap5JsIntegrity = "sha512-Cwi0jz7fz7mrX990DlJ1+rmiH/D9/rjfOoEex8C9qrPRDDqwMPdWV7pJFKzhM10gAAPlufZcWhfMuPN699Ej0w=="  # noqa: E501
+
+    lscacheVersionNumber = "1.0.5"
+    lscacheJsIntegrity = "sha512-ODLwMEfU6d2VYLsGUCJPlIO8lIBGO9u/2Mi9juw6T26RBc0FygKSqYj9GDmxGLErNTOMAdIvj6PaWZo6e0znwQ=="  # noqa: E501
+
+    bootstrapVersion = f"bootstrap-{bootstrapVersionNumber}-dist"
+    jqueryVersion = f"jquery-{jqueryVersionNumber}"
+    dataTablesVersion = f"DataTables-{dataTablesVersionNumber}"
+    lscacheVersion = f"lscache-{lscacheVersionNumber}"
+
+    bootstrapSourceURL = URL.fromText(
+        f"https://github.com/twbs/bootstrap/releases/download/"
+        f"v{bootstrapVersionNumber}/{bootstrapVersion}.zip"
+    )
+
+    jqueryJSSourceURL = URL.fromText(
+        f"https://cdnjs.cloudflare.com/ajax/libs/jquery/"
+        f"{jqueryVersionNumber}/jquery.min.js"
+    )
+
+    jqueryMapSourceURL = URL.fromText(
+        f"https://cdnjs.cloudflare.com/ajax/libs/jquery/"
+        f"{jqueryVersionNumber}/jquery.min.map"
+    )
+
+    dataTablesSourceURL = URL.fromText(
+        f"https://datatables.net/releases/DataTables-{dataTablesVersionNumber}.zip"
+    )
+
+    lscacheJSSourceURL = URL.fromText(
+        f"https://raw.githubusercontent.com/pamelafox/lscache/"
+        f"{lscacheVersionNumber}/lscache.min.js"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -407,14 +407,14 @@ wheels = [
 
 [[package]]
 name = "pyopenssl"
-version = "24.3.0"
+version = "25.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/d4/1067b82c4fc674d6f6e9e8d26b3dff978da46d351ca3bac171544693e085/pyopenssl-24.3.0.tar.gz", hash = "sha256:49f7a019577d834746bc55c5fce6ecbcec0f2b4ec5ce1cf43a9a173b8138bb36", size = 178944 }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/26/e25b4a374b4639e0c235527bbe31c0524f26eda701d79456a7e1877f4cc5/pyopenssl-25.0.0.tar.gz", hash = "sha256:cd2cef799efa3936bb08e8ccb9433a575722b9dd986023f1cabc4ae64e9dac16", size = 179573 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/22/40f9162e943f86f0fc927ebc648078be87def360d9d8db346619fb97df2b/pyOpenSSL-24.3.0-py3-none-any.whl", hash = "sha256:e474f5a473cd7f92221cc04976e48f4d11502804657a08a989fb3be5514c904a", size = 56111 },
+    { url = "https://files.pythonhosted.org/packages/ca/d7/eb76863d2060dcbe7c7e6cccfd95ac02ea0b9acc37745a0d99ff6457aefb/pyOpenSSL-25.0.0-py3-none-any.whl", hash = "sha256:424c247065e46e76a37411b9ab1782541c23bb658bf003772c3405fbaa128e90", size = 56453 },
 ]
 
 [[package]]
@@ -503,7 +503,7 @@ requires-dist = [
     { name = "jwcrypto", specifier = "==1.5.6" },
     { name = "klein", specifier = "==24.8.0" },
     { name = "pymysql", specifier = "==1.1.1" },
-    { name = "pyopenssl", specifier = "==24.3.0" },
+    { name = "pyopenssl", specifier = "==25.0.0" },
     { name = "pyyaml", specifier = "==6.0.2" },
     { name = "service-identity", specifier = "==24.2.0" },
     { name = "twisted", specifier = "==24.11.0" },


### PR DESCRIPTION
we currently rely on several externally-hosted packages that are loaded and cached by IMS when they're first requested. Prior to this change, we didn't verify that those dependencies were the right files.

https://github.com/burningmantech/ranger-ims-server/issues/1517

https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity