### PR TITLE
open Incidents/Field Reports in new tabs when direct entering

### DIFF
--- a/src/ims/element/static/field_reports.js
+++ b/src/ims/element/static/field_reports.js
@@ -205,12 +205,11 @@ function initDataTables() {
         ],
         "createdRow": function (row, fieldReport, index) {
             $(row).click(function () {
-                const url = (
-                    urlReplace(url_viewFieldReports) + fieldReport.number
-                );
-
                 // Open new context with link
-                window.open(url, "Field_Report:" + fieldReport.number);
+                window.open(
+                    urlReplace(url_viewFieldReports) + fieldReport.number,
+                    "Field_Report:" + fieldReport.number,
+                );
             });
             $(row).find(".field_report_created")
                 .attr("title", fullDateTime.format(Date.parse(fieldReport.created)));
@@ -281,7 +280,11 @@ function initSearchField() {
                 // This will work regardless of whether that FR is visible with the current filters.
                 const val = searchInput.value;
                 if (integerRegExp.test(val)) {
-                    window.location = urlReplace(url_viewFieldReportNumber).replace("<number>", val);
+                    // Open new context with link
+                    window.open(
+                        urlReplace(url_viewFieldReports) + val,
+                        "Field_Report:" + val,
+                    );
                 }
             }
         }

--- a/src/ims/element/static/incidents.js
+++ b/src/ims/element/static/incidents.js
@@ -300,11 +300,10 @@ function initDataTables() {
         ],
         "createdRow": function (row, incident, index) {
             $(row).click(function () {
-                const url = viewIncidentsURL + incident.number;
-
                 // Open new context with link
                 window.open(
-                    url, "Incident:" + eventID + "#" + incident.number
+                    viewIncidentsURL + incident.number,
+                    "Incident:" + eventID + "#" + incident.number,
                 );
             });
             $(row).find(".incident_created")
@@ -389,7 +388,11 @@ function initSearchField() {
                 // This will work regardless of whether that incident is visible with the current filters.
                 const val = searchInput.value;
                 if (integerRegExp.test(val)) {
-                    window.location = urlReplace(url_viewIncidentNumber).replace("<number>", val);
+                    // Open new context with link
+                    window.open(
+                        viewIncidentsURL + val,
+                        "Incident:" + eventID + "#" + val,
+                    );
                 }
                 // TODO(srabraham): this works, but I'm not sure yet if it's useful enough to include.
                 //


### PR DESCRIPTION
we already opened these in new browser tabs when you clicked on rows in the tables. This makes it so that when you type the number into the search field and hit enter, you also get sent to those pages in new tabs.