### PR TITLE
use less jQuery, more JavaScript Web APIs

### DIFF
--- a/src/ims/element/static/field_report.js
+++ b/src/ims/element/static/field_report.js
@@ -93,15 +93,14 @@ function initFieldReportPage() {
 // Set the user-visible error information on the page to the provided string.
 function setErrorMessage(msg) {
     msg = "Error: (Cause: " + msg + ")"
-    $("#error_info").removeClass("hidden");
-    $("#error_text").text(msg);
+    document.getElementById("error_info").classList.remove("hidden");
+    document.getElementById("error_text").textContent = msg;
 }
 
 function clearErrorMessage() {
-    $("#error_info").addClass("hidden");
-    $("#error_text").text("");
+    document.getElementById("error_info").classList.add("hidden");
+    document.getElementById("error_text").textContent = "";
 }
-
 
 //
 // Load field report

--- a/src/ims/element/static/field_reports.js
+++ b/src/ims/element/static/field_reports.js
@@ -111,13 +111,13 @@ function initFieldReportsTable() {
 // Set the user-visible error information on the page to the provided string.
 function setErrorMessage(msg) {
     msg = "Error: (Cause: " + msg + ")"
-    $("#error_info").removeClass("hidden");
-    $("#error_text").text(msg);
+    document.getElementById("error_info").classList.remove("hidden");
+    document.getElementById("error_text").textContent = msg;
 }
 
 function clearErrorMessage() {
-    $("#error_info").addClass("hidden");
-    $("#error_text").text("");
+    document.getElementById("error_info").classList.add("hidden");
+    document.getElementById("error_text").textContent = "";
 }
 
 //
@@ -204,15 +204,18 @@ function initDataTables() {
             [1, "dsc"],
         ],
         "createdRow": function (row, fieldReport, index) {
-            $(row).click(function () {
+            row.addEventListener("click", function (e) {
                 // Open new context with link
                 window.open(
                     urlReplace(url_viewFieldReports) + fieldReport.number,
                     "Field_Report:" + fieldReport.number,
                 );
-            });
-            $(row).find(".field_report_created")
-                .attr("title", fullDateTime.format(Date.parse(fieldReport.created)));
+            })
+            row.getElementsByClassName("field_report_created")[0]
+                .setAttribute(
+                    "title",
+                    fullDateTime.format(Date.parse(fieldReport.created)),
+                );
         },
     });
 }

--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -156,13 +156,13 @@ function loadIncident(success) {
 // Set the user-visible error information on the page to the provided string.
 function setErrorMessage(msg) {
     msg = "Error: (Cause: " + msg + ")"
-    $("#error_info").removeClass("hidden");
-    $("#error_text").text(msg);
+    document.getElementById("error_info").classList.remove("hidden");
+    document.getElementById("error_text").textContent = msg;
 }
 
 function clearErrorMessage() {
-    $("#error_info").addClass("hidden");
-    $("#error_text").text("");
+    document.getElementById("error_info").classList.add("hidden");
+    document.getElementById("error_text").textContent = "";
 }
 
 function loadAndDisplayIncident(success) {

--- a/src/ims/element/static/incidents.js
+++ b/src/ims/element/static/incidents.js
@@ -109,13 +109,13 @@ function loadEventFieldReports(success) {
 // Set the user-visible error information on the page to the provided string.
 function setErrorMessage(msg) {
     msg = "Error: (Cause: " + msg + ")"
-    $("#error_info").removeClass("hidden");
-    $("#error_text").text(msg);
+    document.getElementById("error_info").classList.remove("hidden");
+    document.getElementById("error_text").textContent = msg;
 }
 
 function clearErrorMessage() {
-    $("#error_info").addClass("hidden");
-    $("#error_text").text("");
+    document.getElementById("error_info").classList.add("hidden");
+    document.getElementById("error_text").textContent = "";
 }
 
 //
@@ -299,15 +299,18 @@ function initDataTables() {
             [2, "dsc"],
         ],
         "createdRow": function (row, incident, index) {
-            $(row).click(function () {
+            row.addEventListener("click", function (e) {
                 // Open new context with link
                 window.open(
                     viewIncidentsURL + incident.number,
                     "Incident:" + eventID + "#" + incident.number,
                 );
-            });
-            $(row).find(".incident_created")
-                .attr("title", fullDateTime.format(Date.parse(incident.created)));
+            })
+            row.getElementsByClassName("incident_created")[0]
+                .setAttribute(
+                    "title",
+                    fullDateTime.format(Date.parse(incident.created)),
+                );
         },
     });
 }

--- a/src/ims/run/_command.py
+++ b/src/ims/run/_command.py
@@ -96,7 +96,7 @@ class Command:
         application = Application(config=config)
 
         cls.log.info(
-            "Setting up web service at http://{host}:{port}/",
+            "Setting up web service at http://{host}:{port}/ims/app",
             host=host,
             port=port,
         )


### PR DESCRIPTION
Web APIs are the newer thing, and we might as well use them instead of jQuery wherever possible.

unrelated, but also, make a logging statement more useful, so that you can click on its link and go
straight to the web server