### PR TITLE
finish plumbing through per-AccessEntry "always" vs. "onsite"

### DIFF
--- a/conf/imsd-docker-compose-sample.conf
+++ b/conf/imsd-docker-compose-sample.conf
@@ -21,8 +21,6 @@ Admins = Hardware, Loosy
 
 #JWTSecret = DD264110-3A97-4348-9473-6D50B582550C
 
-RequireActive = True
-
 
 [Store:SQLite]
 

--- a/conf/imsd-sample.conf
+++ b/conf/imsd-sample.conf
@@ -21,8 +21,6 @@ Admins = Hardware, Loosy
 
 #JWTSecret = DD264110-3A97-4348-9473-6D50B582550C
 
-RequireActive = True
-
 
 [Store:SQLite]
 

--- a/src/ims/application/_klein.py
+++ b/src/ims/application/_klein.py
@@ -169,9 +169,7 @@ def forbiddenResponse(request: IRequest) -> KleinSynchronousRenderable:
     return textResponse(request, "Permission denied")
 
 
-def friendlyNotAuthorizedResponse(
-    request: IRequest, requireActive: bool
-) -> KleinSynchronousRenderable:
+def friendlyNotAuthorizedResponse(request: IRequest) -> KleinSynchronousRenderable:
     """
     Respond with a FORBIDDEN status, informing the user what went wrong.
     """
@@ -191,13 +189,8 @@ def friendlyNotAuthorizedResponse(
             f"Permissions are granted per-event via positions. These are your positions:\n"  # noqa:E501
             f"    {user.groups}\n"
             f"\n"
-        )
-        if requireActive:
-            message += (
-                f"IMS is currently configured to only permit access to on-site Rangers.\n"  # noqa:E501
-                f"Your current on-site status is '{user.active}', according to Clubhouse.\n"  # noqa:E501
-            )
-        message += (
+            f"Be aware that many permissions are only granted to on-site Rangers.\n"
+            f"Your current on-site status is '{user.active}'.\n"
             "\n"
             "All Rangers are allowed (and encouraged!) to write Field Reports while\n"
             "on playa. Only some positions need access to read and write Incidents.\n"
@@ -452,14 +445,14 @@ class Router(Klein):
         @self.handle_errors(NotAuthorizedError)
         @renderResponse
         def notAuthorizedError(
-            app: Any,
+            app: Any,  # noqa: ARG001
             request: IRequest,
             failure: Failure,  # noqa: ARG001
         ) -> KleinRenderable:
             """
             Not authorized.
             """
-            return friendlyNotAuthorizedResponse(request, app.config.requireActive)
+            return friendlyNotAuthorizedResponse(request)
 
         @self.handle_errors(InvalidCredentialsError)
         @renderResponse

--- a/src/ims/auth/_provider.py
+++ b/src/ims/auth/_provider.py
@@ -233,7 +233,6 @@ class AuthProvider:
 
     _jsonWebKey: JSONWebKey
 
-    requireActive: bool = True
     adminUsers: frozenset[str] = frozenset()
     masterKey: str = ""
 
@@ -339,9 +338,6 @@ class AuthProvider:
 
         An ACL of "**" will always match, even for the None user.
 
-        If the requireActive of this instance is True, all other ACLs will never
-        match a user if the user is not active.
-
         An ACL of "*" matches all users other than the None user.
 
         An ACL of the form "person:{user}" will match a user of one of the
@@ -356,10 +352,6 @@ class AuthProvider:
 
         if user is None:
             return False
-
-        # issue/1540: kill off the global requireActive setting
-        # if self.requireActive and not user.active:
-        #     return False
 
         for a in acl:
             if a.validity == AccessValidity.onsite and not user.active:

--- a/src/ims/auth/test/test_provider.py
+++ b/src/ims/auth/test/test_provider.py
@@ -590,7 +590,6 @@ class AuthProviderTests(TestCase):
             store=self.store(),
             directory=self.directory(),
             jsonWebKey=JSONWebKey.generate(),
-            requireActive=False,
         )
 
         self.assertFalse(
@@ -608,7 +607,6 @@ class AuthProviderTests(TestCase):
             store=self.store(),
             directory=self.directory(),
             jsonWebKey=JSONWebKey.generate(),
-            requireActive=False,
         )
 
         self.assertTrue(
@@ -626,7 +624,6 @@ class AuthProviderTests(TestCase):
             store=self.store(),
             directory=self.directory(),
             jsonWebKey=JSONWebKey.generate(),
-            requireActive=False,
         )
 
         for shortName in user.shortNames:
@@ -651,7 +648,6 @@ class AuthProviderTests(TestCase):
             store=self.store(),
             directory=self.directory(),
             jsonWebKey=JSONWebKey.generate(),
-            requireActive=False,
         )
 
         for groupID in user.groups:
@@ -675,7 +671,6 @@ class AuthProviderTests(TestCase):
             store=self.store(),
             directory=self.directory(),
             jsonWebKey=JSONWebKey.generate(),
-            requireActive=False,
         )
 
         user = TestUser(
@@ -713,7 +708,6 @@ class AuthProviderTests(TestCase):
             store=store,
             directory=self.directory(),
             jsonWebKey=JSONWebKey.generate(),
-            requireActive=False,
         )
         self.successResultOf(store.upgradeSchema())
         event = "2024"
@@ -829,7 +823,6 @@ class AuthProviderTests(TestCase):
             store=store,
             directory=self.directory(),
             jsonWebKey=JSONWebKey.generate(),
-            requireActive=False,
         )
         self.successResultOf(store.upgradeSchema())
         event = "2024"

--- a/src/ims/config/_config.py
+++ b/src/ims/config/_config.py
@@ -246,15 +246,14 @@ class Configuration:
         )
         cls._log.info("Admins: {admins}", admins=tuple(imsAdmins))
 
+        # This setting is no longer in use! The on-site requirement is now
+        # configured per-access entry. See
+        # https://github.com/burningmantech/ranger-ims-server/issues/1540
         active = parser.valueFromConfig(
             "REQUIRE_ACTIVE", "Core", "RequireActive", "true"
         )
         active = active.lower()
-        if active in ("false", "no", "0"):
-            requireActive = False
-        else:
-            requireActive = True
-        cls._log.info("RequireActive: {active}", active=requireActive)
+        cls._log.info("RequireActive (NO LONGER IN USE!): {active}", active=active)
 
         jwtSecret = parser.valueFromConfig("JWT_SECRET", "Core", "JWTSecret")
         if not jwtSecret:
@@ -408,7 +407,6 @@ class Configuration:
             logLevelName=logLevelName,
             masterKey=masterKey,
             port=port,
-            requireActive=requireActive,
             serverRoot=serverRoot,
             storeFactory=storeFactory,
             tokenLifetime=tokenLifetime,
@@ -428,7 +426,6 @@ class Configuration:
     logLevelName: str
     masterKey: str
     port: int
-    requireActive: bool
     serverRoot: Path
     tokenLifetime: TimeDelta
 
@@ -456,7 +453,6 @@ class Configuration:
                 store=self.store,
                 directory=self.directory,
                 jsonWebKey=self.jsonWebKey,
-                requireActive=self.requireActive,
                 adminUsers=self.imsAdmins,
                 masterKey=self.masterKey,
             )

--- a/src/ims/config/test/test_config.py
+++ b/src/ims/config/test/test_config.py
@@ -599,22 +599,6 @@ class ConfigurationTests(TestCase):
 
             self.assertEqual(config.imsAdmins, result)
 
-    def test_fromConfigFile_requireActive(self) -> None:
-        """
-        RequireActive boolean values.
-        """
-
-        def test(value: str) -> bool:
-            with testingEnvironment({"IMS_REQUIRE_ACTIVE": value}):
-                config = Configuration.fromConfigFile(None)
-            return config.requireActive
-
-        for value in ("false", "False", "FALSE", "no", "No", "NO", "0"):
-            self.assertFalse(test(value))
-
-        for value in ("true", "True", "TRUE", "yes", "Yes", "YES", "1"):
-            self.assertTrue(test(value))
-
     @given(text(alphabet=printable, min_size=1))
     def test_fromConfigFile_jwtSecret(self, secret: str) -> None:
         """

--- a/src/ims/element/admin/events/template.xhtml
+++ b/src/ims/element/admin/events/template.xhtml
@@ -5,12 +5,19 @@
 
 <body>
 <div t:render="container">
+  For each event, you can configure access for individuals and for positions.
+  You can also choose when each permission applies, whether it be only
+  when a Ranger is marked on-site in Clubhouse, or all year long (always).
   <div class="row" id="event_access_container">
     <div class="col-sm-12 py-1 event_access">
       <div class="card">
         <label class="card-header">Access for <span class="event_name"/> (<span class="access_mode"/>):</label>
         <ul class="list-group list-group-small list-group-flush card-body">
           <li class="list-group-item ps-3">
+            <select class="access_validity" onchange="setValidity(this)">
+              <option value="always">Always</option>
+              <option value="onsite">On-Site</option>
+            </select>
             <button class="badge btn btn-danger remove-badge float-end" onclick="removeAccess(this)">
               X
             </button>

--- a/src/ims/element/static/admin_events.js
+++ b/src/ims/element/static/admin_events.js
@@ -106,6 +106,7 @@ function updateEventAccess(event, mode) {
 
         entryItem.append(accessEntry.expression);
         entryItem.attr("value", accessEntry.expression);
+        entryItem.find(".access_validity").val(accessEntry.validity);
 
         entryContainer.append(entryItem);
     }
@@ -244,6 +245,44 @@ function removeAccess(sender) {
 
     function fail() {
         loadAccessControlList(refresh);
+    }
+
+    sendACL(edits, ok, fail);
+}
+
+function setValidity(sender) {
+    const container = $(sender).parents(".event_access:first");
+    const event = container.find(".event_name:first").text();
+    const mode = container.find(".access_mode:first").text();
+    const expression = $(sender).parent().attr("value").trim();
+
+    const acl = accessControlList[event][mode].slice();
+
+    newVal = {
+        "expression": expression,
+        "validity": sender.value,
+    };
+
+    acl.push(newVal);
+
+    const edits = {};
+    edits[event] = {};
+    edits[event][mode] = acl;
+
+    function refresh() {
+        for (const mode of accessModes) {
+            updateEventAccess(event, mode);
+        }
+    }
+
+    function ok() {
+        loadAccessControlList(refresh);
+        sender.value = "";  // Clear input field
+    }
+
+    function fail() {
+        loadAccessControlList(refresh);
+        controlHasError($(sender));
     }
 
     sendACL(edits, ok, fail);


### PR DESCRIPTION
This deprecates the old "RequireActive" config setting, and makes that fully configurable per-AccessEntry via the admin events page.

https://github.com/burningmantech/ranger-ims-server/issues/1540

<img width="255" alt="image" src="https://github.com/user-attachments/assets/e1934e7e-984c-4a7d-90fe-050b73c46ff5" />
