### PR TITLE
make various static resources set Cache-Control with max-age

### DIFF
--- a/src/ims/application/_api.py
+++ b/src/ims/application/_api.py
@@ -136,7 +136,6 @@ class APIApplication:
     storeObserver: DataStoreEventSourceLogObserver
 
     @router.route(_unprefix(URLs.ping), methods=("HEAD", "GET"))
-    @static
     def pingResource(self, request: IRequest) -> KleinRenderable:
         """
         Ping (health check) endpoint.

--- a/src/ims/application/_main.py
+++ b/src/ims/application/_main.py
@@ -31,7 +31,7 @@ from twisted.web.static import File
 import ims.element
 from ims.config import Configuration, URLs
 from ims.ext.json_ext import jsonTextFromObject
-from ims.ext.klein import ContentType, HeaderName, static
+from ims.ext.klein import ContentType, HeaderName
 
 from ._api import APIApplication
 from ._auth import AuthApplication
@@ -110,7 +110,6 @@ class MainApplication:
     #
 
     @router.route(URLs.root, methods=("HEAD", "GET"))
-    @static
     def rootEndpoint(self, request: IRequest) -> KleinRenderable:
         """
         Server root page.
@@ -118,7 +117,6 @@ class MainApplication:
         return "IMS"
 
     @router.route(URLs.prefix, methods=("HEAD", "GET"))
-    @static
     def prefixEndpoint(self, request: IRequest) -> KleinRenderable:
         """
         IMS root page.
@@ -128,7 +126,6 @@ class MainApplication:
         return redirect(request, URLs.app)
 
     @router.route(URLs.static, branch=True)
-    @static
     def staticEndpoint(self, request: IRequest) -> KleinRenderable:
         """
         Return endpoint for static resources collection.
@@ -140,7 +137,6 @@ class MainApplication:
     #
 
     @router.route(URLs.urlsJS, methods=("HEAD", "GET"))
-    @static
     def urlsEndpoint(self, request: IRequest) -> KleinRenderable:
         """
         JavaScript variables for service URLs.
@@ -160,7 +156,6 @@ class MainApplication:
     #
 
     @router.route(URLs.api, branch=True)
-    @static
     def apiApplicationEndpoint(self, request: IRequest) -> KleinRenderable:
         """
         API application resource.
@@ -168,7 +163,6 @@ class MainApplication:
         return self.apiApplication.router.resource()
 
     @router.route(URLs.authApp, branch=True)
-    @static
     def authApplicationEndpoint(self, request: IRequest) -> KleinRenderable:
         """
         Auth application resource.
@@ -176,7 +170,6 @@ class MainApplication:
         return self.authApplication.router.resource()
 
     @router.route(URLs.external, branch=True)
-    @static
     def externalApplicationEndpoint(self, request: IRequest) -> KleinRenderable:
         """
         External application resource.
@@ -184,7 +177,6 @@ class MainApplication:
         return cast(IResource, self.externalApplication.router.resource())
 
     @router.route(URLs.app, branch=True)
-    @static
     def webApplicationEndpoint(self, request: IRequest) -> KleinRenderable:
         """
         Web application resource.

--- a/src/ims/application/_web.py
+++ b/src/ims/application/_web.py
@@ -41,7 +41,6 @@ from ims.element.incident.report_template import FieldReportTemplatePage
 from ims.element.incident.reports import FieldReportsPage
 from ims.element.incident.reports_template import FieldReportsTemplatePage
 from ims.element.root import RootPage
-from ims.ext.klein import static
 from ims.model import Event
 from ims.store import NoSuchFieldReportError
 
@@ -101,7 +100,6 @@ class WebApplication:
         return redirect(request, url)
 
     @router.route(_unprefix(URLs.admin), methods=("HEAD", "GET"))
-    @static
     async def adminPage(self, request: IRequest) -> KleinSynchronousRenderable:
         """
         Endpoint for admin page.
@@ -172,7 +170,6 @@ class WebApplication:
         return IncidentsPage(config=self.config, event=event)
 
     @router.route(_unprefix(URLs.viewIncidentsTemplate), methods=("HEAD", "GET"))
-    @static
     def viewIncidentsTemplatePage(self, request: IRequest) -> KleinRenderable:
         """
         Endpoint for the incidents page template.
@@ -203,7 +200,6 @@ class WebApplication:
         return IncidentPage(config=self.config, event=event, number=numberValue)
 
     @router.route(_unprefix(URLs.viewIncidentTemplate), methods=("HEAD", "GET"))
-    @static
     def viewIncidentTemplatePage(self, request: IRequest) -> KleinRenderable:
         """
         Endpoint for the incident page template.
@@ -229,7 +225,6 @@ class WebApplication:
         return FieldReportsPage(config=self.config, event=event)
 
     @router.route(_unprefix(URLs.viewFieldReportsTemplate), methods=("HEAD", "GET"))
-    @static
     def viewFieldReportsTemplatePage(self, request: IRequest) -> KleinRenderable:
         """
         Endpoint for the field reports page template.
@@ -276,7 +271,6 @@ class WebApplication:
         return FieldReportPage(config=config, event=event, number=fieldReportNumber)
 
     @router.route(_unprefix(URLs.viewFieldReportTemplate), methods=("HEAD", "GET"))
-    @static
     def viewFieldReportTemplatePage(self, request: IRequest) -> KleinRenderable:
         """
         Endpoint for the field report page template.

--- a/src/ims/ext/klein.py
+++ b/src/ims/ext/klein.py
@@ -89,7 +89,7 @@ else:
     from uuid import uuid4
 
     _staticETag = uuid4().hex
-    _maxAge = 0
+    _maxAge = 60 * 60  # 60 minutes
 
 _cacheControl = f"max-age={_maxAge}"
 


### PR DESCRIPTION
We might as well have clients cache JS files for a while, since those don't change. This removes the @static decorator from a bunch of routes that aren't really static, since if we started setting max-age>0 for those, we would be getting caching in the wrong places.

https://github.com/burningmantech/ranger-ims-server/issues/1548