### PR TITLE
stop showing legal names, start linking to Clubhouse users

### DIFF
--- a/src/ims/element/incident/incident/template.xhtml
+++ b/src/ims/element/incident/incident/template.xhtml
@@ -14,6 +14,7 @@
   const pageTemplateURL           = url_viewIncidentTemplate;
   const incidentsURL              = urlReplace(url_incidents);
   const viewIncidentsURL          = urlReplace(url_viewIncidents);
+  const clubhousePersonURL        = "https://ranger-clubhouse.burningman.org/person";
 
   const concentricStreetNameByID  = <json t:render="concentric_street_name_by_id"/>;
 

--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -551,12 +551,16 @@ function drawRangers() {
     for (const handle of handles) {
         let ranger = null;
         if (personnel?.[handle] == null) {
-            ranger = handle;
+            ranger = textAsHTML(handle);
         } else {
-            ranger = rangerAsString(personnel[handle]);
+            const person = personnel[handle];
+            ranger = $("<a>", {
+                text: textAsHTML(rangerAsString(person)),
+                href: `${clubhousePersonURL}/${person.directory_id}`,
+            });
         }
         const item = _rangerItem.clone();
-        item.append(textAsHTML(ranger));
+        item.append(ranger);
         item.attr("value", textAsHTML(handle));
         items.push(item);
     }
@@ -593,10 +597,6 @@ function drawRangersToAdd() {
 
 function rangerAsString(ranger) {
     let result = ranger.handle;
-
-    if (ranger.name) {
-        result += " (" + ranger.name + ")";
-    }
 
     if (ranger.status === "vintage") {
         result += "*";


### PR DESCRIPTION
This is just the easy frontend piece, in which we stop displaying Ranger legal names, and start linking to the Clubhouse person page for each Ranger. The more tedious part will be removing name from the server, and having the Clubhouse URL stored as a config that gets pushed up from command line flag all the way into the frontend. I'll leave that for a followup PR.

https://github.com/burningmantech/ranger-ims-server/issues/1536