### PR TITLE
drop Ranger legal names altogether from IMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Each month below should look like the following, using the same ordering for the
 - Created a slight pause after search field input prior to actually running the search. This will reduce perceived latency in typing/deleting in the search field. https://github.com/burningmantech/ranger-ims-server/issues/1481 https://github.com/burningmantech/ranger-ims-server/pull/1483
 - Started Field Report numbering from 1 each event, as we already did for Incidents. https://github.com/burningmantech/ranger-ims-server/pull/1506
 - Enhanced the "permission denied" error page, to make it more descriptive for when we block access for an authenticated Ranger. https://github.com/burningmantech/ranger-ims-server/pull/1530
+- Stopped showing Ranger legal names in IMS; started linking from Ranger handles into Clubhouse person pages instead. https://github.com/burningmantech/ranger-ims-server/issues/1536
 
 ### Added
 

--- a/src/ims/directory/clubhouse_db/_dms.py
+++ b/src/ims/directory/clubhouse_db/_dms.py
@@ -145,7 +145,7 @@ class DutyManagementSystem:
             """
             select
                 id,
-                callsign, first_name, mi, last_name, email,
+                callsign, email,
                 status, on_site, password
             from person
             where status in ('active', 'inactive', 'vintage', 'auditor')
@@ -155,7 +155,6 @@ class DutyManagementSystem:
         return {
             directoryID: Ranger(
                 handle=handle,
-                name=fullName(first, middle, last),
                 status=statusFromID(status),
                 email=(email,),
                 enabled=bool(enabled),
@@ -165,9 +164,6 @@ class DutyManagementSystem:
             for (
                 directoryID,
                 handle,
-                first,
-                middle,
-                last,
                 email,
                 status,
                 enabled,
@@ -263,15 +259,6 @@ class DutyManagementSystem:
             return self._state._personnel
         except AttributeError:
             raise DMSError("No personnel data loaded.") from None
-
-
-def fullName(first: str, middle: str, last: str) -> str:
-    """
-    Compose parts of a name into a full name.
-    """
-    if middle:
-        return f"{first} {middle}. {last}"
-    return f"{first} {last}"
 
 
 def statusFromID(strValue: str) -> RangerStatus:

--- a/src/ims/directory/clubhouse_db/test/dummy.py
+++ b/src/ims/directory/clubhouse_db/test/dummy.py
@@ -71,23 +71,20 @@ class DummyConnectionPool:
         sql = query.sql()
 
         def fixPassword(
-            person: tuple[int, str, str, str, str, str, str, bool, str],
-        ) -> tuple[int, str, str, str, str, str, str, bool, str]:
+            person: tuple[int, str, str, str, bool, str],
+        ) -> tuple[int, str, str, str, bool, str]:
             return (
                 person[0],
                 person[1],
                 person[2],
                 person[3],
                 person[4],
-                person[5],
-                person[6],
-                person[7],
-                hashPassword(person[8]),
+                hashPassword(person[5]),
             )
 
         if sql == (
             "select "
-            "id, callsign, first_name, mi, last_name, "
+            "id, callsign, "
             "email, status, on_site, password "
             "from person where status in "
             "('active', 'inactive', 'vintage', 'auditor')"
@@ -117,9 +114,6 @@ cannedPersonnel = (
     (
         1,
         "Easy E",
-        "Eric",
-        "P",
-        "Grant",
         "easye@example.com",
         "active",
         True,
@@ -128,9 +122,6 @@ cannedPersonnel = (
     (
         2,
         "Weso",
-        "Wes",
-        "",
-        "Johnson",
         "weso@example.com",
         "active",
         True,
@@ -139,9 +130,6 @@ cannedPersonnel = (
     (
         3,
         "SciFi",
-        "Fred",
-        "",
-        "McCord",
         "scifi@example.com",
         "active",
         True,
@@ -150,9 +138,6 @@ cannedPersonnel = (
     (
         4,
         "Slumber",
-        "Sleepy",
-        "T",
-        "Dwarf",
         "slumber@example.com",
         "inactive",
         False,
@@ -161,9 +146,6 @@ cannedPersonnel = (
     (
         5,
         "Tool",
-        "Wilfredo",
-        "",
-        "Sanchez",
         "tool@example.com",
         "vintage",
         True,
@@ -172,9 +154,6 @@ cannedPersonnel = (
     (
         6,
         "Tulsa",
-        "Curtis",
-        "",
-        "Kline",
         "tulsa@example.com",
         "vintage",
         True,

--- a/src/ims/directory/clubhouse_db/test/test_dms.py
+++ b/src/ims/directory/clubhouse_db/test/test_dms.py
@@ -22,7 +22,7 @@ from typing import cast
 
 from ims.ext.trial import TestCase
 
-from .._dms import DutyManagementSystem, fullName
+from .._dms import DutyManagementSystem
 from .dummy import DummyADBAPI, DummyConnectionPool, cannedPersonnel
 
 
@@ -99,16 +99,3 @@ class DutyManagementSystemTests(TestCase):
             [p.handle for p in personnel],
             [p[1] for p in cannedPersonnel],
         )
-
-
-class UtilTests(TestCase):
-    """
-    Tests for L{ims.directory.clubhouse_db}.
-    """
-
-    def test_fullName(self) -> None:
-        """
-        L{fullName} combines first/middle/last correctly.
-        """
-        self.assertEqual(fullName("Bob", "", "Smith"), "Bob Smith")
-        self.assertEqual(fullName("Bob", "Q", "Smith"), "Bob Q. Smith")

--- a/src/ims/directory/file/_directory.py
+++ b/src/ims/directory/file/_directory.py
@@ -66,10 +66,6 @@ def rangerFromMapping(mapping: Mapping[str, Any]) -> Ranger:
     if type(handle) is not str:
         raise DirectoryError(f"Ranger handle must be text: {handle!r}")
 
-    name = mapping.get("name", "")
-    if type(name) is not str:
-        raise DirectoryError(f"Ranger name must be text: {name!r}")
-
     _status = mapping.get("status", "")
     if type(_status) is not str:
         raise DirectoryError(f"Ranger status must be text: {_status!r}")
@@ -99,7 +95,6 @@ def rangerFromMapping(mapping: Mapping[str, Any]) -> Ranger:
 
     return Ranger(
         handle=handle,
-        name=name,
         status=status,
         email=email,
         enabled=enabled,

--- a/src/ims/directory/file/test/test_directory.py
+++ b/src/ims/directory/file/test/test_directory.py
@@ -49,7 +49,6 @@ __all__ = ()
 
 rangerBeepBoop = Ranger(
     handle="Beep Boop",
-    name="Ann Droid",
     status=RangerStatus.active,
     email=("ad@example.com",),
     enabled=True,
@@ -58,7 +57,6 @@ rangerBeepBoop = Ranger(
 )
 rangerSlumber = Ranger(
     handle="Slumber",
-    name="Sleepy T. Dwarf",
     status=RangerStatus.inactive,
     email=("slumber@example.com", "sleepy@example.com"),
     enabled=True,
@@ -67,7 +65,6 @@ rangerSlumber = Ranger(
 )
 rangerYouRine = Ranger(
     handle="YouRine",
-    name="I. P. Freely",
     status=RangerStatus.active,
     email=("yourine@example.com",),
     enabled=False,
@@ -76,7 +73,6 @@ rangerYouRine = Ranger(
 )
 rangerNine = Ranger(
     handle="Nine",
-    name="Nein Statushaven",
     status=RangerStatus.other,
     email=(),
     enabled=True,
@@ -103,7 +99,6 @@ def rangerAsDict(ranger: Ranger, random: Random) -> dict[str, Any]:
 
     return {
         "handle": ranger.handle,
-        "name": ranger.name,
         "status": ranger.status.name,
         "email": email,
         "enabled": ranger.enabled,
@@ -199,19 +194,6 @@ class UtilityTests(TestCase):
 
         e = self.assertRaises(DirectoryError, rangerFromMapping, rangerDict)
         self.assertEqual(str(e), f"Ranger handle must be text: {handle!r}")
-
-    @given(rangers(), randoms())
-    @settings(max_examples=10)
-    def test_rangerFromMapping_nameNotText(
-        self, ranger: Ranger, random: Random
-    ) -> None:
-        ranger = ranger.replace(directoryID=None)
-        rangerDict = rangerAsDict(ranger, random)
-        name = rangerDict["name"].encode("utf-8")
-        rangerDict["name"] = name
-
-        e = self.assertRaises(DirectoryError, rangerFromMapping, rangerDict)
-        self.assertEqual(str(e), f"Ranger name must be text: {name!r}")
 
     @given(rangers(), randoms())
     @settings(max_examples=10)

--- a/src/ims/directory/test/test_directory.py
+++ b/src/ims/directory/test/test_directory.py
@@ -126,7 +126,6 @@ class DirectoryTests(TestCase):
         [
             Ranger(
                 handle="A",
-                name="A",
                 status=RangerStatus.active,
                 email="same@example.com",
                 enabled=True,
@@ -135,7 +134,6 @@ class DirectoryTests(TestCase):
             ),
             Ranger(
                 handle="B",
-                name="B",
                 status=RangerStatus.active,
                 email="same@example.com",
                 enabled=True,
@@ -144,7 +142,6 @@ class DirectoryTests(TestCase):
             ),
             Ranger(
                 handle="C",
-                name="C",
                 status=RangerStatus.active,
                 email="same@example.com",
                 enabled=True,

--- a/src/ims/model/_ranger.py
+++ b/src/ims/model/_ranger.py
@@ -65,13 +65,14 @@ class Ranger(ReplaceMixIn):
     """
     Ranger
 
-    An Ranger contains information about a Black Rock Ranger; a person record
+    A Ranger contains information about a Black Rock Ranger; a person record
     specific to a Black Rock Ranger.
     """
 
     handle: str
-    name: str
     status: RangerStatus
+    # email is not fed out via the personnel endpoint, but we need it in the server
+    # in order to permit authentication using email address rather than handle.
     email: frozenset[str] = field(converter=freezeStrings, default=frozenset[str]())
     enabled: bool
     directoryID: str | None
@@ -80,4 +81,4 @@ class Ranger(ReplaceMixIn):
     )
 
     def __str__(self) -> str:
-        return f"{self.status} {self.handle} ({self.name})"
+        return f"{self.status} {self.handle}"

--- a/src/ims/model/json/_ranger.py
+++ b/src/ims/model/json/_ranger.py
@@ -40,7 +40,6 @@ class RangerJSONKey(Enum):
     """
 
     handle = "handle"
-    name = "name"
     status = "status"
     # email is intentionally not serialized, since no web client needs it
     enabled = "enabled"
@@ -54,7 +53,6 @@ class RangerJSONType(Enum):
     """
 
     handle = str
-    name = str  # type: ignore[assignment]
     status = RangerStatus
     # email is intentionally not serialized, since no web client needs it
     enabled = bool

--- a/src/ims/model/json/test/json_helpers.py
+++ b/src/ims/model/json/test/json_helpers.py
@@ -185,7 +185,6 @@ def jsonFromRangerStatus(status: RangerStatus) -> str:
 def jsonFromRanger(ranger: Ranger) -> dict[str, Any]:
     return {
         "handle": ranger.handle,
-        "name": ranger.name,
         "status": jsonFromRangerStatus(ranger.status),
         # email is intentionally not serialized
         "enabled": ranger.enabled,

--- a/src/ims/model/strategies.py
+++ b/src/ims/model/strategies.py
@@ -498,7 +498,6 @@ def rangers(draw: Callable[..., Any]) -> Ranger:
     """
     return Ranger(
         handle=draw(rangerHandles()),
-        name=draw(text(min_size=1)),
         status=draw(sampled_from(RangerStatus)),
         email=draw(lists(emails())),
         enabled=draw(booleans()),

--- a/src/ims/model/test/test_ranger.py
+++ b/src/ims/model/test/test_ranger.py
@@ -59,6 +59,4 @@ class RangerTests(TestCase):
         """
         Ranger status renders as a string.
         """
-        self.assertEqual(
-            str(ranger), f"{ranger.status} {ranger.handle} ({ranger.name})"
-        )
+        self.assertEqual(str(ranger), f"{ranger.status} {ranger.handle}")


### PR DESCRIPTION
They were already gone from the UI in an earlier PR. This completes the job, and removes them from the backend too.

https://github.com/burningmantech/ranger-ims-server/issues/1536