### PR TITLE
update Incident page on changes to Field Reports

### DIFF
--- a/src/ims/element/static/ims.js
+++ b/src/ims/element/static/ims.js
@@ -1080,10 +1080,6 @@ function subscribeToUpdates(closed) {
         send.postMessage(JSON.parse(e.data));
     }, true);
 
-    // TODO(issue/1498): SSEs are now firing for Field Report updates, but we need
-    //  to find an appropriate way for the various pages to handle these updates
-    //  (i.e. without excessive volume of API calls or "unauthorized" errors from
-    //  users with limited access).
     eventSource.addEventListener("FieldReport", function(e) {
         const send = new BroadcastChannel(fieldReportChannelName);
         localStorage.setItem(lastSseIDKey, e.lastEventId);

--- a/src/ims/store/_db.py
+++ b/src/ims/store/_db.py
@@ -1859,7 +1859,6 @@ class DatabaseStore(IMSDataStore):
 
         self._log.info(
             "{author} updated field report #{fieldReportNumber}: {attribute}={value}",
-            storeWriteClass=FieldReport,
             query=query,
             eventID=eventID,
             fieldReportNumber=fieldReportNumber,


### PR DESCRIPTION
This keeps the Incident page fully up-to-date with changes on the server to Field Reports. It does this in a selective manner, just loading the particular FR that was changed.

https://github.com/burningmantech/ranger-ims-server/issues/1498