### PR TITLE
roll our own simple caching, remove lscache

### DIFF
--- a/src/ims/application/_external.py
+++ b/src/ims/application/_external.py
@@ -748,19 +748,6 @@ class ExternalApplication:
             *names,
         )
 
-    @router.route(_unprefix(URLs.lscacheJS), methods=("HEAD", "GET"))
-    @static
-    async def lscacheJSResource(self, request: IRequest) -> KleinRenderable:
-        """
-        Endpoint for lscache.
-        """
-        request.setHeader(HeaderName.contentType.value, ContentType.javascript.value)
-        return await self.cachedResource(
-            request,
-            self.config.externalDeps.lscacheJSSourceURL,
-            f"{self.config.externalDeps.lscacheVersion}.min.js",
-        )
-
     async def cacheFromURL(self, url: URL, name: str) -> Path:
         """
         Download a resource and cache it.

--- a/src/ims/config/_external_deps.py
+++ b/src/ims/config/_external_deps.py
@@ -37,13 +37,9 @@ class ExternalDeps:
     dataTablesJsIntegrity = "sha512-aB+KD1UH6xhwz0ZLqIGK+if/B83XzgnFzDJtf195axOEqurA7ahWCpl8wgXWVfcMslhnmYigAjYXShrJSlxgWg=="  # noqa: E501
     dataTablesBootstrap5JsIntegrity = "sha512-Cwi0jz7fz7mrX990DlJ1+rmiH/D9/rjfOoEex8C9qrPRDDqwMPdWV7pJFKzhM10gAAPlufZcWhfMuPN699Ej0w=="  # noqa: E501
 
-    lscacheVersionNumber = "1.0.5"
-    lscacheJsIntegrity = "sha512-ODLwMEfU6d2VYLsGUCJPlIO8lIBGO9u/2Mi9juw6T26RBc0FygKSqYj9GDmxGLErNTOMAdIvj6PaWZo6e0znwQ=="  # noqa: E501
-
     bootstrapVersion = f"bootstrap-{bootstrapVersionNumber}-dist"
     jqueryVersion = f"jquery-{jqueryVersionNumber}"
     dataTablesVersion = f"DataTables-{dataTablesVersionNumber}"
-    lscacheVersion = f"lscache-{lscacheVersionNumber}"
 
     bootstrapSourceURL = URL.fromText(
         f"https://github.com/twbs/bootstrap/releases/download/"
@@ -62,9 +58,4 @@ class ExternalDeps:
 
     dataTablesSourceURL = URL.fromText(
         f"https://datatables.net/releases/DataTables-{dataTablesVersionNumber}.zip"
-    )
-
-    lscacheJSSourceURL = URL.fromText(
-        f"https://raw.githubusercontent.com/pamelafox/lscache/"
-        f"{lscacheVersionNumber}/lscache.min.js"
     )

--- a/src/ims/config/_urls.py
+++ b/src/ims/config/_urls.py
@@ -99,8 +99,6 @@ class URLs:
         "js", "dataTables.bootstrap5.min.js"
     )
 
-    lscacheJS: ClassVar[URL] = external.child("lscache.min.js")
-
     # Web application
 
     app: ClassVar[URL] = prefix.child("app").child("")

--- a/src/ims/element/incident/incident/template.xhtml
+++ b/src/ims/element/incident/incident/template.xhtml
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" t:render="root">
 
-<head t:render="head" imports="lscache,ims,viewIncident"/>
+<head t:render="head" imports="ims,viewIncident"/>
 
 <body/>
 

--- a/src/ims/element/page/_page.py
+++ b/src/ims/element/page/_page.py
@@ -93,8 +93,6 @@ class Page(Element):
             return cast(str, self.config.externalDeps.dataTablesBootstrap5JsIntegrity)
         if depName == "jquery":
             return cast(str, self.config.externalDeps.jqueryJsIntegrity)
-        if depName == "lscache":
-            return cast(str, self.config.externalDeps.lscacheJsIntegrity)
         return None
 
     @renderer

--- a/src/ims/element/static/ims.js
+++ b/src/ims/element/static/ims.js
@@ -1086,3 +1086,20 @@ function subscribeToUpdates(closed) {
         send.postMessage(JSON.parse(e.data));
     }, true);
 }
+
+function cacheSet(key, value, ttlMinutes) {
+    localStorage.setItem(`ims.${key}`, JSON.stringify(value));
+    localStorage.setItem(`ims.${key}.deadline`, `${Date.now()+ttlMinutes*60*1000}`);
+}
+
+function cacheGet(key) {
+    const val = localStorage.getItem(`ims.${key}`);
+    const deadline = localStorage.getItem(`ims.${key}.deadline`);
+    if (val == null || !deadline) {
+        return null;
+    }
+    if (Date.now() > new Date(Number.parseInt(deadline))) {
+        return null;
+    }
+    return JSON.parse(val);
+}

--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -271,12 +271,12 @@ function localCachePersonnel(personnel) {
         alert("Attempt to cache undefined personnel")
         return;
     }
-    lscache.set("ims.personnel", personnel, 10);
+    cacheSet("personnel", personnel, 20 /* minutes */);
 }
 
 
 function localLoadPersonnel() {
-    return lscache.get("ims.personnel");
+    return cacheGet("personnel");
 }
 
 
@@ -333,12 +333,12 @@ function localCacheIncidentTypes(incidentTypes) {
         alert("Attempt to cache undefined incident types")
         return;
     }
-    lscache.set("ims.incident_types", incidentTypes, 10);
+    cacheSet("incident_types", incidentTypes, 20 /* minutes */);
 }
 
 
 function localLoadIncidentTypes() {
-    return lscache.get("ims.incident_types");
+    return cacheGet("incident_types");
 }
 
 


### PR DESCRIPTION
External frontend dependencies kind of suck, and we were bringing in lscache for a rather trivial use case. Let's just do it ourselves.

https://github.com/burningmantech/ranger-ims-server/issues/1556