### PR TITLE
stop logging on unknown event store updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Each month below should look like the following, using the same ordering for the
 ### Removed
 
 - Dropped "\*\*"-style ACLs, which we didn't use and didn't actually work at all. https://github.com/burningmantech/ranger-ims-server/pull/1553
+- Removed JavaScript dependency on lscache; replaced it with simple in-house caching. https://github.com/burningmantech/ranger-ims-server/pull/1558
 
 ### Fixed
 

--- a/src/ims/application/_eventsource.py
+++ b/src/ims/application/_eventsource.py
@@ -158,11 +158,8 @@ class DataStoreEventSourceLogObserver:
                 "field_report_number": fieldReportNumber,
             }
         else:
-            self._log.critical(
-                "Unknown data store event class {eventClass} sent event: {event}",
-                eventClass=eventClass,
-                event=loggerEvent,
-            )
+            # It's some EventClass for which we don't notify the EventSource,
+            # so there's nothing to do.
             return None
         self._counter[0] += 1
         return Event(


### PR DESCRIPTION
This is expected behavior when an entity is modified for which we have no intention of firing SSEs, e.g. ReportEntries

https://github.com/burningmantech/ranger-ims-server/issues/467