### PR TITLE
don't show attached FRs for a new incident

### DIFF
--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -437,6 +437,9 @@ function loadFieldReport(fieldReportNumber, success) {
 let attachedFieldReports = null;
 
 function loadAttachedFieldReports() {
+    if (incidentNumber == null) {
+        return;
+    }
     _attachedFieldReports = [];
     for (const fr of allFieldReports) {
         if (fr.incident === incidentNumber) {


### PR DESCRIPTION
fixing a silly bug I introduced yesterday, in which any new incident was showing as having a bunch of FRs attached to it. That's because I was checking if "fr.incident === incidentNumber" for each of those FRs, and it turns out that null === null, so we showed all those FRs that weren't attached to any incident yet.