### PR TITLE
use HTTP cache rather than LocalStorage for personnel, incident types

### DIFF
--- a/src/ims/application/_api.py
+++ b/src/ims/application/_api.py
@@ -211,6 +211,7 @@ class APIApplication:
         )
 
     @router.route(_unprefix(URLs.personnel), methods=("HEAD", "GET"))
+    @static
     async def personnelResource(self, request: IRequest) -> KleinSynchronousRenderable:
         """
         Personnel endpoint.
@@ -243,6 +244,7 @@ class APIApplication:
         )
 
     @router.route(_unprefix(URLs.incidentTypes), methods=("HEAD", "GET"))
+    @static
     async def incidentTypesResource(
         self, request: IRequest
     ) -> KleinSynchronousRenderable:

--- a/src/ims/element/static/ims.js
+++ b/src/ims/element/static/ims.js
@@ -1087,19 +1087,18 @@ function subscribeToUpdates(closed) {
     }, true);
 }
 
-function cacheSet(key, value, ttlMinutes) {
-    localStorage.setItem(`ims.${key}`, JSON.stringify(value));
-    localStorage.setItem(`ims.${key}.deadline`, `${Date.now()+ttlMinutes*60*1000}`);
+// Remove the old LocalStorage caches that IMS no longer uses, so that
+// they can't act against the ~5 MB per-domain limit of HTML5 LocalStorage.
+// This can probably be removed after the 2025 event, when all the relevant
+// computers have their caches purged.
+function cleanupOldCaches() {
+    localStorage.removeItem("lscache-ims.incident_types");
+    localStorage.removeItem("lscache-ims.incident_types-cacheexpiration");
+    localStorage.removeItem("lscache-ims.personnel");
+    localStorage.removeItem("lscache-ims.personnel-cacheexpiration");
+    localStorage.removeItem("ims.incident_types");
+    localStorage.removeItem("ims.incident_types.deadline")
+    localStorage.removeItem("ims.personnel");
+    localStorage.removeItem("ims.personnel.deadline");
 }
-
-function cacheGet(key) {
-    const val = localStorage.getItem(`ims.${key}`);
-    const deadline = localStorage.getItem(`ims.${key}.deadline`);
-    if (val == null || !deadline) {
-        return null;
-    }
-    if (Date.now() > new Date(Number.parseInt(deadline))) {
-        return null;
-    }
-    return JSON.parse(val);
-}
+cleanupOldCaches();

--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -20,11 +20,11 @@
 
 function initIncidentPage() {
     function loadedIncident() {
-        loadPersonnelAndCache(function() {
+        loadPersonnel(function() {
             drawRangers();
             drawRangersToAdd();
         });
-        loadIncidentTypesAndCache(drawIncidentTypesToAdd);
+        loadIncidentTypes(drawIncidentTypesToAdd);
         loadAllFieldReports(renderFieldReportData);
 
         // for a new incident
@@ -216,23 +216,6 @@ function renderFieldReportData() {
 
 let personnel = null;
 
-function loadPersonnelAndCache(success) {
-    const cached = localLoadPersonnel();
-
-    function loadedPersonnel() {
-        localCachePersonnel(personnel);
-        success();
-    }
-
-    if (cached == null) {
-        loadPersonnel(loadedPersonnel);
-    } else {
-        personnel = cached;
-        success();
-    }
-}
-
-
 function loadPersonnel(success) {
     function ok(data, status, xhr) {
         const _personnel = {};
@@ -275,33 +258,11 @@ function localCachePersonnel(personnel) {
 }
 
 
-function localLoadPersonnel() {
-    return cacheGet("personnel");
-}
-
-
 //
 // Load incident types
 //
 
 let incidentTypes = null;
-
-
-function loadIncidentTypesAndCache(success) {
-    const cached = localLoadIncidentTypes();
-
-    function loadedIncidentTypes() {
-        localCacheIncidentTypes(incidentTypes);
-        success();
-    }
-
-    if (cached == null) {
-        loadIncidentTypes(loadedIncidentTypes);
-    } else {
-        incidentTypes = cached;
-        success();
-    }
-}
 
 
 function loadIncidentTypes(success) {
@@ -334,11 +295,6 @@ function localCacheIncidentTypes(incidentTypes) {
         return;
     }
     cacheSet("incident_types", incidentTypes, 20 /* minutes */);
-}
-
-
-function localLoadIncidentTypes() {
-    return cacheGet("incident_types");
 }
 
 

--- a/src/ims/ext/klein.py
+++ b/src/ims/ext/klein.py
@@ -89,9 +89,13 @@ else:
     from uuid import uuid4
 
     _staticETag = uuid4().hex
-    _maxAge = 60 * 60  # 60 minutes
+    _maxAge = 60 * 20  # 20 minutes
 
-_cacheControl = f"max-age={_maxAge}"
+# Technically only some of our resources should be private, such
+# as the personnel and incident_types endpoints, but there's
+# minimal downside  (and less code complexity) in just making them
+# all private.
+_cacheControl = f"max-age={_maxAge}, private"
 
 
 def static(f: KleinRouteHandler) -> KleinRouteHandler:


### PR DESCRIPTION
I recently removed the lscache dependency, because external frontend deps are nice to avoid wherever possible. After reading more about LocalStorage though, I think we're better off dropping it entirely for these local caches. Our use case, i.e. caching responses from a couple of endpoints, is better served by just using Cache-Control-controlled HTTP caching. Not only does this simplify our code, but it removes any worry about the 5 MB per-domain LocalStorage limit in most browsers, and it stops us from keeping data in the browser of a (potentially shared) machine after the user signs out.

https://github.com/burningmantech/ranger-ims-server/pull/1558