### PR TITLE
make TWISTED_SESSION cookie use more secure

### DIFF
--- a/src/ims/auth/_provider.py
+++ b/src/ims/auth/_provider.py
@@ -302,6 +302,22 @@ class AuthProvider:
             groups=tuple(IMSGroupID(gid) for gid in claims.ranger_positions.split(",")),
         )
 
+    def _enhanceSessionCookie(self, request: IRequest) -> None:
+        """
+        Set some additional features on the Twisted Session cookie.
+
+        That cookie is used to authenticate the user on all requests after login, so
+        it's important to protect it as best as we can from XSRF or XSS.
+        """
+        cookies = getattr(request, "cookies", [])
+        for i in range(len(cookies)):
+            if b"TWISTED_SESSION" not in cookies[i]:
+                continue
+            if b"SameSite" not in cookies[i]:
+                cookies[i] += b"; SameSite=lax"
+            if b"HttpOnly" not in cookies[i]:
+                cookies[i] += b"; HttpOnly"
+
     def checkAuthentication(self, request: IRequest) -> None:
         """
         Check whether the request has previously been authenticated, and if so,
@@ -315,17 +331,7 @@ class AuthProvider:
                 session = request.getSession()
                 user = getattr(session, "user", None)
 
-            # Twisted doesn't use modern security features on its session cookie, but
-            # it really should. That cookie authenticates the user in all requests
-            # after login, so it should be treated with sensitivity.
-            cookies = getattr(request, "cookies", [])
-            for i in range(len(cookies)):
-                if b"TWISTED_SESSION" not in cookies[i]:
-                    continue
-                if b"SameSite" not in cookies[i]:
-                    cookies[i] += b"; SameSite=lax"
-                if b"HttpOnly" not in cookies[i]:
-                    cookies[i] += b"; HttpOnly"
+            self._enhanceSessionCookie(request)
 
             request.user = user  # type: ignore[attr-defined]
 

--- a/uv.lock
+++ b/uv.lock
@@ -16,11 +16,11 @@ wheels = [
 
 [[package]]
 name = "attrs"
-version = "24.3.0"
+version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/c8/6260f8ccc11f0917360fc0da435c5c9c7504e3db174d5a12a1494887b045/attrs-24.3.0.tar.gz", hash = "sha256:8f5c07333d543103541ba7be0e2ce16eeee8130cb0b3f9238ab904ce1e85baff", size = 805984 }
+sdist = { url = "https://files.pythonhosted.org/packages/49/7c/fdf464bcc51d23881d110abd74b512a42b3d5d376a55a831b44c603ae17f/attrs-25.1.0.tar.gz", hash = "sha256:1c97078a80c814273a76b2a298a932eb681c87415c11dee0a6921de7f1b02c3e", size = 810562 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/aa/ab0f7891a01eeb2d2e338ae8fecbe57fcebea1a24dbb64d45801bfab481d/attrs-24.3.0-py3-none-any.whl", hash = "sha256:ac96cd038792094f438ad1f6ff80837353805ac950cd2aa0e0625ef19850c308", size = 63397 },
+    { url = "https://files.pythonhosted.org/packages/fc/30/d4986a882011f9df997a55e6becd864812ccfcd821d64aac8570ee39f719/attrs-25.1.0-py3-none-any.whl", hash = "sha256:c75a69e28a550a7e93789579c22aa26b0f5b83b75dc4e08fe092980051e1090a", size = 63152 },
 ]
 
 [[package]]
@@ -495,7 +495,7 @@ unit = [
 [package.metadata]
 requires-dist = [
     { name = "arrow", specifier = "==1.3.0" },
-    { name = "attrs", specifier = "==24.3.0" },
+    { name = "attrs", specifier = "==25.1.0" },
     { name = "bcrypt", specifier = "==4.2.1" },
     { name = "cattrs", specifier = "==24.1.2" },
     { name = "cryptography", specifier = "==44.0.0" },


### PR DESCRIPTION
Twisted doesn't set a SameSite value on its session cookie. That session cookie is what authenticates the user for every request after initial login. Browsers are supposed to interpret SameSite unset as "lax", but Chrome interprets that as something a little more lenient still than "lax". The right thing to do is to actually set a SameSite value, and lax is appropriate for our needs.
https://web.dev/articles/samesite-cookies-explained#samesitelax_by_default

HttpOnly forbids JavaScript from accessing the cookie directly (though it'll still get passed implicitly when HTTP requests are made). This helps protect against XSS, since a malicious script is unable to read a cookie in order to steal it.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#httponly

https://github.com/burningmantech/ranger-ims-server/issues/1562