### PR TITLE
permit regular expression searches in UI, allow bookmarking

### DIFF
--- a/src/ims/element/incident/incidents_template/template.xhtml
+++ b/src/ims/element/incident/incidents_template/template.xhtml
@@ -10,16 +10,22 @@
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
-          <p class="modal-title fs-5" id="helpModalLabel">Keyboard shortcuts</p>
+          <p class="modal-title fs-5" id="helpModalLabel">Incidents help</p>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
         </div>
         <div class="modal-body">
-          <code>n</code>: create new Incident <br/>
-          <code>a</code>: show all Incidents <br/>
-          <code>/</code>: jump to search field <br/>
-          <p class="mt-2 mb-0">Also...</p>
+          <p class="mt-2 mb-0">Keyboard shortcuts</p>
           <ul>
-            <li>In the search field, you can type an IMS number then press <code>⏎</code> to be redirected to that Incident</li>
+            <li><code>n</code>: create new Incident <br/></li>
+            <li><code>a</code>: show all Incidents <br/></li>
+            <li><code>/</code>: jump to search field <br/></li>
+          </ul>
+          <p class="mt-2 mb-0">In the search field</p>
+          <ul>
+            <li>Type an IMS number then press <code>⏎</code> to be redirected to that Incident</li>
+            <li>Type a search string then press <code>⏎</code> to get a bookmarkable URL</li>
+            <li>Search by regular expression by enclosing a pattern with slashes, e.g. <code>/r.nger/</code> or <code>/\b(dog|cat)\b/</code></li>
+            <li>All searches are case insensitive</li>
           </ul>
         </div>
       </div>

--- a/src/ims/element/incident/reports_template/template.xhtml
+++ b/src/ims/element/incident/reports_template/template.xhtml
@@ -10,16 +10,22 @@
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
-          <p class="modal-title fs-5" id="helpModalLabel">Keyboard shortcuts</p>
+          <p class="modal-title fs-5" id="helpModalLabel">Field Reports help</p>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
         </div>
         <div class="modal-body">
-          <code>n</code>: create new Field Report <br/>
-          <code>a</code>: show all Field Reports <br/>
-          <code>/</code>: jump to search field <br/><br/>
-          <p class="mt-2 mb-0">Also...</p>
+          <p class="mt-2 mb-0">Keyboard shortcuts</p>
           <ul>
-            <li>In the search field, you can type an FR number then press <code>⏎</code> to be redirected to that Field Report</li>
+            <li><code>n</code>: create new Field Report <br/></li>
+            <li><code>a</code>: show all Field Reports <br/></li>
+            <li><code>/</code>: jump to search field <br/><br/></li>
+          </ul>
+          <p class="mt-2 mb-0">In the search field</p>
+          <ul>
+            <li>Type an FR number then press <code>⏎</code> to be redirected to that Field Report</li>
+            <li>Type a search string then press <code>⏎</code> to get a bookmarkable URL</li>
+            <li>Search by regular expression by enclosing a pattern with slashes, e.g. <code>/r.nger/</code> or <code>/\b(dog|cat)\b/</code></li>
+            <li>All searches are case insensitive</li>
           </ul>
         </div>
       </div>

--- a/src/ims/element/static/field_reports.js
+++ b/src/ims/element/static/field_reports.js
@@ -257,6 +257,25 @@ function initSearchField() {
 
     // Search field handling
     const searchInput = document.getElementById("search_input");
+
+    const searchAndDraw = function () {
+        let q = searchInput.value;
+        let isRegex = false;
+        if (q.startsWith("/") && q.endsWith("/")) {
+            isRegex = true;
+            q = q.slice(1, q.length-1);
+        }
+        fieldReportsTable.search(q, isRegex);
+        fieldReportsTable.draw();
+    }
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const queryString = urlParams.get("q");
+    if (queryString) {
+        searchInput.value = queryString;
+        searchAndDraw();
+    }
+
     searchInput.addEventListener("keyup",
         function () {
             // Delay the search in case the user is still typing.
@@ -264,11 +283,7 @@ function initSearchField() {
             // very slow, and it's super annoying for a user when
             // the page fully locks up before they're done typing.
             clearTimeout(_searchDelayTimer);
-            const val = this.value;
-            _searchDelayTimer = setTimeout(function () {
-                fieldReportsTable.search(val);
-                fieldReportsTable.draw();
-            }, _searchDelayMs);
+            _searchDelayTimer = setTimeout(searchAndDraw, _searchDelayMs);
         }
     );
     searchInput.addEventListener("keydown",
@@ -288,6 +303,12 @@ function initSearchField() {
                         urlReplace(url_viewFieldReports) + val,
                         "Field_Report:" + val,
                     );
+                }
+                // Redirect to a bookmarkable URL that shows the results for the search query.
+                if (val !== "") {
+                    window.location.replace(
+                        `${urlReplace(url_viewFieldReports)}?q=${encodeURIComponent(val)}`,
+                    )
                 }
             }
         }

--- a/src/ims/element/static/ims.js
+++ b/src/ims/element/static/ims.js
@@ -552,7 +552,7 @@ function fieldReportAsString(report) {
 }
 
 
-// Return all user-entered report text for a given incident.
+// Return all user-entered report text for a given incident as a single string.
 function reportTextFromIncident(incident) {
     const texts = [];
 
@@ -584,7 +584,7 @@ function reportTextFromIncident(incident) {
         }
     }
 
-    return texts.join("");
+    return texts.join(" ");
 }
 
 

--- a/src/ims/element/static/incidents.js
+++ b/src/ims/element/static/incidents.js
@@ -365,6 +365,25 @@ function initSearchField() {
 
     // Search field handling
     const searchInput = document.getElementById("search_input");
+
+    const searchAndDraw = function () {
+        let q = searchInput.value;
+        let isRegex = false;
+        if (q.startsWith("/") && q.endsWith("/")) {
+            isRegex = true;
+            q = q.slice(1, q.length-1);
+        }
+        incidentsTable.search(q, isRegex);
+        incidentsTable.draw();
+    }
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const queryString = urlParams.get("q");
+    if (queryString) {
+        searchInput.value = queryString;
+        searchAndDraw();
+    }
+
     searchInput.addEventListener("keyup",
         function () {
             // Delay the search in case the user is still typing.
@@ -372,11 +391,7 @@ function initSearchField() {
             // very slow, and it's super annoying for a user when
             // the page fully locks up before they're done typing.
             clearTimeout(_searchDelayTimer);
-            const val = this.value;
-            _searchDelayTimer = setTimeout(function () {
-                incidentsTable.search(val);
-                incidentsTable.draw();
-            }, _searchDelayMs);
+            _searchDelayTimer = setTimeout(searchAndDraw, _searchDelayMs);
         }
     );
     searchInput.addEventListener("keydown",
@@ -397,14 +412,12 @@ function initSearchField() {
                         "Incident:" + eventID + "#" + val,
                     );
                 }
-                // TODO(srabraham): this works, but I'm not sure yet if it's useful enough to include.
-                //
-                // // If there's exactly one visible Incident given the current search filters, then go to it.
-                // const rowsVisible = incidentsTable.rows({search:'applied'});
-                // if (rowsVisible.count() === 1) {
-                //     const targetIncident = rowsVisible.data()[0].number;
-                //     window.location = urlReplace(url_viewIncidentNumber).replace("<number>", targetIncident);
-                // }
+                // Redirect to a bookmarkable URL that shows the results for the search query.
+                if (val !== "") {
+                    window.location.replace(
+                        `${viewIncidentsURL}?q=${encodeURIComponent(val)}`,
+                    )
+                }
             }
         }
     );


### PR DESCRIPTION
I don't expect most users to notice this feature, which is totally fine by me. The major use case for this is to allow "OR"-based searching, which the current DataTables "smart search" approach doesn't support.

For example, this will let someone bookmark this (not URL-encoded here, for clarity):
https://.../ims/app/events/2024/incidents/?q=/\b(dog|cat|snake)\b/ to easily find any incident that contains the word "dog" or "cat" or "snake". The word boundary check might be useful too, as shown in that example.

The approach of specifying a regex by enclosing a pattern with slashes is what GitHub uses, so I think nerds on the playa will be fairly comfortable with it.

https://github.com/burningmantech/ranger-ims-server/issues/1570

P.S. I had to make an interesting little tweak in reportTextFromIncident, changing `return texts.join("")` to `return texts.join(" ")`. That's because that separator is what's used to push together all the report entry texts, and you lose word boundaries between different entry texts if you join on an empty string.