### PR TITLE
add navbar links to Incidents and Field Reports

### DIFF
--- a/src/ims/element/incident/report_template/_report_template.py
+++ b/src/ims/element/incident/report_template/_report_template.py
@@ -36,3 +36,4 @@ class FieldReportTemplatePage(Page):
     """
 
     name: str = title
+    hideH1: bool = True

--- a/src/ims/element/incident/report_template/template.xhtml
+++ b/src/ims/element/incident/report_template/template.xhtml
@@ -23,7 +23,7 @@
 
   <!-- Identifiers -->
 
-  <div class="row">
+  <div class="row py-1">
     <div class="col-sm-4">
       <div class="py-1 input-group">
         <label for="field_report_number" class="control-label input-group-text">FR #</label>

--- a/src/ims/element/page/nav/template.xhtml
+++ b/src/ims/element/page/nav/template.xhtml
@@ -53,12 +53,23 @@
           </ul>
         </li>
       </ul>
+
+      <!-- Links to Incidents and Field Reports for current event -->
+      <ul class="navbar-nav">
+        <li class="nav-item">
+          <a id="active-event-incidents" class="nav-link hidden" href="">Incidents</a>
+        </li>
+        <li class="nav-item">
+          <a id="active-event-field-reports" class="nav-link hidden" href="">Field Reports</a>
+        </li>
+      </ul>
+
       <!-- this keeps the nav_login thing on the right when the events dropdown is hidden -->
       <ul class="navbar-nav me-auto"/>
 
       <!-- Theme dropdown -->
       <ul class="navbar-nav">
-        <li class="nav-item dropdown">
+        <li class="nav-item dropdown" title="Color scheme">
           <button class="btn btn-link nav-link py-2 px-0 px-lg-2 dropdown-toggle d-flex align-items-center"
                   id="bd-theme" type="button" aria-expanded="false" data-bs-toggle="dropdown"
                   data-bs-display="static" aria-label="Toggle theme (auto)">

--- a/src/ims/element/static/ims.js
+++ b/src/ims/element/static/ims.js
@@ -337,6 +337,14 @@ function loadBody(success) {
         if (typeof eventID !== "undefined") {
             $(".event-id").text(eventID);
             $(".event-id").addClass("active-event");
+
+            const eventIncidents = document.getElementById("active-event-incidents");
+            eventIncidents.setAttribute("href", urlReplace(url_viewIncidents));
+            eventIncidents.classList.remove("hidden");
+
+            const eventFieldReports = document.getElementById("active-event-field-reports");
+            eventFieldReports.setAttribute("href", urlReplace(url_viewFieldReports));
+            eventFieldReports.classList.remove("hidden");
         }
 
         if (success) {

--- a/src/ims/element/static/style.css
+++ b/src/ims/element/static/style.css
@@ -15,6 +15,7 @@
 
 .navbar-brand {
   --bs-navbar-brand-font-size: 1rem;
+  --bs-navbar-brand-margin-end: 0.5rem;
   padding-bottom: 0;
 }
 


### PR DESCRIPTION
This makes it much easier to navigate around IMS.
These links will style badly if the event name is very long, but there's no problem at all for 4-character names, which are all that really matter.

This commit also makes a few other minor style tweaks.

<img width="384" alt="image" src="https://github.com/user-attachments/assets/8c9df9bf-b48e-4bfa-81dd-ae5b5b6ae6bb" />
