### PR TITLE
support multi-select of incident types on Incidents page

### DIFF
--- a/src/ims/element/incident/incidents_template/template.xhtml
+++ b/src/ims/element/incident/incidents_template/template.xhtml
@@ -60,14 +60,14 @@
         <span class="selection">All</span>
       </button>
       <ul class="dropdown-menu">
-        <li id="show_state_all" onclick="showState('all', true);">
-          <a href="#" class="name dropdown-item">All States</a>
+        <li id="show_state_all">
+          <a href="#" class="name dropdown-item" onclick="showState('all', true); return false;">All States</a>
         </li>
-        <li id="show_state_open" onclick="showState('open', true);">
-          <a href="#" class="name dropdown-item">Open</a>
+        <li id="show_state_open">
+          <a href="#" class="name dropdown-item" onclick="showState('open', true); return false;">Open</a>
         </li>
-        <li id="show_state_active" onclick="showState('active', true);">
-          <a href="#" class="name dropdown-item">Active</a>
+        <li id="show_state_active">
+          <a href="#" class="name dropdown-item" onclick="showState('active', true); return false;">Active</a>
         </li>
       </ul>
 
@@ -82,19 +82,19 @@
         <span class="selection">All Days</span>
       </button>
       <ul class="dropdown-menu">
-        <li id="show_days_all" onclick="showDays('all', true);">
+        <li id="show_days_all" onclick="showDays('all', true); return false;">
           <a href="#" class="name dropdown-item">All Days</a>
         </li>
-        <li id="show_days_0" onclick="showDays(0, true);">
+        <li id="show_days_0" onclick="showDays(0, true); return false;">
           <a href="#" class="name dropdown-item">Today</a>
         </li>
-        <li id="show_days_1" onclick="showDays(1, true);">
+        <li id="show_days_1" onclick="showDays(1, true); return false;">
           <a href="#" class="name dropdown-item">Last 2 Days</a>
         </li>
-        <li id="show_days_2" onclick="showDays(2, true);">
+        <li id="show_days_2" onclick="showDays(2, true); return false;">
           <a href="#" class="name dropdown-item">Last 3 Days</a>
         </li>
-        <li id="show_days_3" onclick="showDays(3, true);">
+        <li id="show_days_3" onclick="showDays(3, true); return false;">
           <a href="#" class="name dropdown-item">Last 4 Days</a>
         </li>
       </ul>
@@ -104,15 +104,12 @@
               type="button"
               class="btn btn-light btn-sm dropdown-toggle"
               data-bs-toggle="dropdown"
+              data-bs-auto-close="outside"
       >
-
-        <span class="selection">All Types</span>
+        Types
       </button>
       <ul id="ul_show_type" class="dropdown-menu">
-        <li id="show_type_all" onclick="showType('all', true);">
-          <a href="#" class="name dropdown-item">All Types</a>
-        </li>
-        <!-- Additional li will be inserted here by JQuery -->
+        <!-- li will be inserted here by JQuery -->
       </ul>
 
       <button
@@ -125,16 +122,16 @@
         <span class="selection">All Rows</span>
       </button>
       <ul class="dropdown-menu">
-        <li id="show_rows_all" onclick="showRows('all', true);">
+        <li id="show_rows_all" onclick="showRows('all', true); return false;">
           <a href="#" class="name dropdown-item">All Rows</a>
         </li>
-        <li id="show_rows_25" onclick="showRows(  25, true);">
+        <li id="show_rows_25" onclick="showRows(  25, true); return false;">
           <a href="#" class="name dropdown-item">25 Rows</a>
         </li>
-        <li id="show_rows_50" onclick="showRows(  50, true);">
+        <li id="show_rows_50" onclick="showRows(  50, true); return false;">
           <a href="#" class="name dropdown-item">50 Rows</a>
         </li>
-        <li id="show_rows_100" onclick="showRows( 100, true);">
+        <li id="show_rows_100" onclick="showRows( 100, true); return false;">
           <a href="#" class="name dropdown-item">100 Rows</a>
         </li>
       </ul>

--- a/src/ims/element/incident/reports_template/template.xhtml
+++ b/src/ims/element/incident/reports_template/template.xhtml
@@ -60,20 +60,20 @@
         <span class="selection">All Days</span>
       </button>
       <ul class="dropdown-menu">
-        <li id="show_days_all" onclick="showDays('all', true);">
-          <a href="#" class="name dropdown-item">All Days</a>
+        <li id="show_days_all">
+          <a href="#" class="name dropdown-item" onclick="showDays('all', true); return false;">All Days</a>
         </li>
-        <li id="show_days_0" onclick="showDays(0, true);">
-          <a href="#" class="name dropdown-item">Today</a>
+        <li id="show_days_0">
+          <a href="#" class="name dropdown-item" onclick="showDays(0, true); return false;">Today</a>
         </li>
-        <li id="show_days_1" onclick="showDays(1, true);">
-          <a href="#" class="name dropdown-item">Last 2 Days</a>
+        <li id="show_days_1">
+          <a href="#" class="name dropdown-item" onclick="showDays(1, true); return false;">Last 2 Days</a>
         </li>
-        <li id="show_days_2" onclick="showDays(2, true);">
-          <a href="#" class="name dropdown-item">Last 3 Days</a>
+        <li id="show_days_2">
+          <a href="#" class="name dropdown-item" onclick="showDays(2, true); return false;">Last 3 Days</a>
         </li>
-        <li id="show_days_3" onclick="showDays(3, true);">
-          <a href="#" class="name dropdown-item">Last 4 Days</a>
+        <li id="show_days_3">
+          <a href="#" class="name dropdown-item" onclick="showDays(3, true); return false;">Last 4 Days</a>
         </li>
       </ul>
 
@@ -86,17 +86,17 @@
         <span class="selection">All Rows</span>
       </button>
       <ul class="dropdown-menu">
-        <li id="show_rows_all" onclick="showRows('all', true);">
-          <a href="#" class="name dropdown-item">All Rows</a>
+        <li id="show_rows_all">
+          <a href="#" class="name dropdown-item" onclick="showRows('all', true); return false;">All Rows</a>
         </li>
-        <li id="show_rows_25" onclick="showRows(  25, true);">
-          <a href="#" class="name dropdown-item">25 Rows</a>
+        <li id="show_rows_25">
+          <a href="#" class="name dropdown-item" onclick="showRows(  25, true); return false;">25 Rows</a>
         </li>
-        <li id="show_rows_50" onclick="showRows(  50, true);">
-          <a href="#" class="name dropdown-item">50 Rows</a>
+        <li id="show_rows_50">
+          <a href="#" class="name dropdown-item" onclick="showRows(  50, true); return false;">50 Rows</a>
         </li>
-        <li id="show_rows_100" onclick="showRows( 100, true);">
-          <a href="#" class="name dropdown-item">100 Rows</a>
+        <li id="show_rows_100">
+          <a href="#" class="name dropdown-item" onclick="showRows( 100, true); return false;">100 Rows</a>
         </li>
       </ul>
     </div>

--- a/src/ims/element/static/field_reports.js
+++ b/src/ims/element/static/field_reports.js
@@ -228,12 +228,13 @@ function initTableButtons() {
         .children(".col-sm-6:first")
         .replaceWith($("#button_container"));
 
-    const urlParams = new URLSearchParams(window.location.search);
+    const fragment = window.location.hash.startsWith("#") ? window.location.hash.substring(1) : window.location.hash;
+    const fragmentParams = new URLSearchParams(fragment);
 
     // Set button defaults
 
-    showDays(urlParams.get("days")??defaultDaysBack, false);
-    showRows(urlParams.get("rows")??defaultRows, false);
+    showDays(fragmentParams.get("days")??defaultDaysBack, false);
+    showRows(fragmentParams.get("rows")??defaultRows, false);
 }
 
 
@@ -256,7 +257,7 @@ function initSearchField() {
     const searchInput = document.getElementById("search_input");
 
     const searchAndDraw = function () {
-        pushWindowState();
+        replaceWindowState();
         let q = searchInput.value;
         let isRegex = false;
         if (q.startsWith("/") && q.endsWith("/")) {
@@ -267,8 +268,9 @@ function initSearchField() {
         fieldReportsTable.draw();
     }
 
-    const urlParams = new URLSearchParams(window.location.search);
-    const queryString = urlParams.get("q");
+    const fragment = window.location.hash.startsWith("#") ? window.location.hash.substring(1) : window.location.hash;
+    const fragmentParams = new URLSearchParams(fragment);
+    const queryString = fragmentParams.get("q");
     if (queryString) {
         searchInput.value = queryString;
         searchAndDraw();
@@ -438,6 +440,6 @@ function replaceWindowState() {
 
     // Next step is to create search params for the other filters too
 
-    const newURL = `${urlReplace(url_viewFieldReports)}?${new URLSearchParams(newParams).toString()}`;
+    const newURL = `${urlReplace(url_viewFieldReports)}#${new URLSearchParams(newParams).toString()}`;
     window.history.replaceState(null, null, newURL);
 }

--- a/src/ims/element/static/style.css
+++ b/src/ims/element/static/style.css
@@ -316,3 +316,14 @@ h1 {
 .hidden {
   display: none !important;
 }
+
+.dropdown-item-checkable {
+  padding: var(--bs-dropdown-item-padding-y) 1.5rem;
+}
+
+.dropdown-item-checked::before {
+  position: absolute;
+  left: .4rem;
+  content: '✓';
+  font-weight: 600;
+}


### PR DESCRIPTION
This also swaps us over to using the URL fragment (i.e. the part after the "#") to save filter parameters. Those allow for longer inputs than search params, and they're fully client-side, which is fine for our purposes.

To support that, I had to get a bunch of onclick handlers to return false, to prevent redirects to href="#", since that would stomp over my attempts to set the fragment.

https://github.com/burningmantech/ranger-ims-server/issues/1581