### PR TITLE
add "(blank)" and "(other)" options to Incident Type filter

### DIFF
--- a/src/ims/element/incident/incidents_template/template.xhtml
+++ b/src/ims/element/incident/incidents_template/template.xhtml
@@ -109,7 +109,9 @@
         Types
       </button>
       <ul id="ul_show_type" class="dropdown-menu">
-        <a class="dropdown-item" href="#" onclick="toggleCheckAllTypes(); return false;">All/None</a>
+        <a class="dropdown-item" href="#" onclick="toggleCheckAllTypes(); return false;">Select All</a>
+        <a id="show_blank_type" class="dropdown-item dropdown-item-checkable dropdown-item-checked" href="#">(blank)</a>
+        <a id="show_other_type" class="dropdown-item dropdown-item-checkable dropdown-item-checked" href="#">(other)</a>
         <!-- li will be inserted here by JQuery -->
       </ul>
 


### PR DESCRIPTION
blank is for Incidents with no assigned Incident Type

other is for Incidents with an inactive or nonexistent Incident Type. Those types don't show up separately in the filter dropdown.

fixes #1585