### PR TITLE
add "lastModified" to Incident entity, add column in DataTable

### DIFF
--- a/src/ims/element/incident/incidents_template/template.xhtml
+++ b/src/ims/element/incident/incidents_template/template.xhtml
@@ -166,6 +166,7 @@
     <tr>
       <th>#</th>
       <th>Created</th>
+      <th>Modified</th>
       <th>State</th>
       <th>Rangers</th>
       <th>Location</th>
@@ -178,6 +179,7 @@
     <tr>
       <th>#</th>
       <th>Created</th>
+      <th>Modified</th>
       <th>State</th>
       <th>Rangers</th>
       <th>Location</th>

--- a/src/ims/element/static/ims.js
+++ b/src/ims/element/static/ims.js
@@ -505,10 +505,7 @@ function incidentAsString(incident) {
     if (incident.number == null) {
         return "New Incident";
     }
-    return (
-        "IMS #" + incident.number + ": " +
-        summarizeIncident(incident)
-    );
+    return `#${incident.number}: ${summarizeIncident(incident)} (${incident.event})`;
 }
 
 
@@ -517,11 +514,8 @@ function fieldReportAsString(report) {
     if (report.number == null) {
         return "New Field Report";
     }
-    return (
-        "FR #" + report.number +
-        " (" + fieldReportAuthor(report) + "): " +
-        summarizeFieldReport(report)
-    );
+    return `FR #${report.number} (${fieldReportAuthor(report)}): ` +
+        `${summarizeFieldReport(report)} (${report.event})`;
 }
 
 

--- a/src/ims/element/static/incidents.js
+++ b/src/ims/element/static/incidents.js
@@ -242,13 +242,20 @@ function initDataTables() {
                 "render": renderDate,
             },
             {   // 2
+                "name": "incident_last_modified",
+                "className": "incident_last_modified text-center",
+                "data": "last_modified",
+                "defaultContent": null,
+                "render": renderDate,
+            },
+            {   // 3
                 "name": "incident_state",
                 "className": "incident_state text-center",
                 "data": "state",
                 "defaultContent": null,
                 "render": renderState,
             },
-            {   // 3
+            {   // 4
                 "name": "incident_ranger_handles",
                 "className": "incident_ranger_handles",
                 "data": "ranger_handles",
@@ -256,14 +263,14 @@ function initDataTables() {
                 "render": renderSafeSorted,
                 "width": "6em",
             },
-            {   // 4
+            {   // 5
                 "name": "incident_location",
                 "className": "incident_location",
                 "data": "location",
                 "defaultContent": "",
                 "render": renderLocation,
             },
-            {   // 5
+            {   // 6
                 "name": "incident_types",
                 "className": "incident_types",
                 "data": "incident_types",
@@ -271,7 +278,7 @@ function initDataTables() {
                 "render": renderSafeSorted,
                 "width": "5em",
             },
-            {   // 6
+            {   // 7
                 "name": "incident_summary",
                 "className": "incident_summary",
                 "data": "summary",
@@ -294,6 +301,11 @@ function initDataTables() {
                 .setAttribute(
                     "title",
                     fullDateTime.format(Date.parse(incident.created)),
+                );
+            row.getElementsByClassName("incident_last_modified")[0]
+                .setAttribute(
+                    "title",
+                    fullDateTime.format(Date.parse(incident.last_modified)),
                 );
         },
     });
@@ -435,19 +447,6 @@ function initSearchField() {
 //
 
 function initSearch() {
-    function modifiedAfter(incident, timestamp) {
-        if (timestamp < Date.parse(incident.created)) {
-            return true;
-        }
-
-        for (const entry of incident.report_entries??[]) {
-            if (timestamp < Date.parse(entry.created)) {
-                return true;
-            }
-        }
-
-      return false;
-    }
 
     $.fn.dataTable.ext.search.push(
         function(settings, rowData, rowIndex) {
@@ -472,7 +471,7 @@ function initSearch() {
 
             if (
                 _showModifiedAfter != null &&
-                ! modifiedAfter(incident, _showModifiedAfter)
+                Date.parse(incident.last_modified) < _showModifiedAfter
             ) {
                 return false
             }

--- a/src/ims/model/_incident.py
+++ b/src/ims/model/_incident.py
@@ -23,7 +23,7 @@ Incident
 from collections.abc import Iterable, Sequence
 from datetime import datetime as DateTime
 
-from attrs import field, frozen
+from attrs import converters, field, frozen
 
 from ims.ext.attr import sorted_tuple
 
@@ -53,6 +53,9 @@ class Incident(ReplaceMixIn):
     eventID: str
     number: int
     created: DateTime = field(converter=normalizeDateTime)
+    lastModified: DateTime | None = field(
+        converter=converters.optional(normalizeDateTime)
+    )
     state: IncidentState
     priority: IncidentPriority
     summary: str | None

--- a/src/ims/model/json/_incident.py
+++ b/src/ims/model/json/_incident.py
@@ -47,6 +47,7 @@ class IncidentJSONKey(Enum):
     eventID = "event"
     number = "number"
     created = "created"
+    lastModified = "last_modified"
     state = "state"
     priority = "priority"
     summary = "summary"
@@ -65,6 +66,7 @@ class IncidentJSONType(Enum):
     eventID = str
     number = int
     created = DateTime
+    lastModified = DateTime | None
     state = IncidentState
     priority = IncidentPriority
     summary = str | None

--- a/src/ims/model/json/test/json_helpers.py
+++ b/src/ims/model/json/test/json_helpers.py
@@ -128,6 +128,7 @@ def jsonFromIncident(incident: Incident) -> dict[str, Any]:
         "event": jsonSerialize(incident.eventID),
         "number": jsonSerialize(incident.number),
         "created": jsonSerialize(incident.created),
+        "last_modified": jsonSerialize(incident.lastModified),
         "state": jsonSerialize(incident.state),
         "priority": jsonSerialize(incident.priority),
         "summary": jsonSerialize(incident.summary),

--- a/src/ims/model/strategies.py
+++ b/src/ims/model/strategies.py
@@ -392,21 +392,23 @@ def incidents(
 
     types = [t.name for t in draw(lists(incidentTypes()))]
 
+    created = draw(dateTimes(beforeNow=beforeNow, fromNow=fromNow))
+    entries = draw(
+        lists(reportEntries(automatic=automatic, beforeNow=beforeNow, fromNow=fromNow))
+    )
+    lastModified = max(re.created for re in entries) if entries else created
     return Incident(
         eventID=event.id,
         number=number,
-        created=draw(dateTimes(beforeNow=beforeNow, fromNow=fromNow)),
+        created=created,
+        lastModified=lastModified,
         state=draw(incidentStates()),
         priority=draw(incidentPriorities()),
         summary=draw(incidentSummaries()),
         location=draw(locations()),
         rangerHandles=draw(lists(rangerHandles())),
         incidentTypes=types,
-        reportEntries=draw(
-            lists(
-                reportEntries(automatic=automatic, beforeNow=beforeNow, fromNow=fromNow)
-            )
-        ),
+        reportEntries=entries,
         fieldReportNumbers=frozenset(),
     )
 

--- a/src/ims/store/test/incident.py
+++ b/src/ims/store/test/incident.py
@@ -56,6 +56,7 @@ aNewIncident = Incident(
     eventID=anEvent.id,
     number=0,
     created=DateTime.now(UTC) + TimeDelta(seconds=1),
+    lastModified=DateTime.now(UTC) + TimeDelta(seconds=2),
     state=IncidentState.new,
     priority=IncidentPriority.normal,
     summary="A thing happened",
@@ -70,6 +71,7 @@ anIncident1 = Incident(
     eventID=anEvent.id,
     number=1,
     created=DateTime.now(UTC) + TimeDelta(seconds=2),
+    lastModified=DateTime.now(UTC) + TimeDelta(seconds=3),
     state=IncidentState.new,
     priority=IncidentPriority.normal,
     summary="A thing happened",
@@ -84,6 +86,7 @@ anIncident2 = Incident(
     eventID=anEvent2.id,
     number=325,
     created=DateTime.now(UTC) + TimeDelta(seconds=3),
+    lastModified=DateTime.now(UTC) + TimeDelta(seconds=4),
     state=IncidentState.new,
     priority=IncidentPriority.normal,
     summary="Another thing happened 🙂",
@@ -884,6 +887,10 @@ class DataStoreIncidentTests(DataStoreTests):
                     if store.dateTimesEqual(valueA, valueB):
                         continue
                     messages.append(f"{name} delta: {valueA - valueB}")
+                elif name == "lastModified":
+                    # this field is calculated on read, and shouldn't be equal
+                    # to what was written
+                    continue
                 elif name == "reportEntries":
                     if store.reportEntriesEqual(valueA, valueB, ignoreAutomatic):
                         continue


### PR DESCRIPTION
Before this change, we were figuring out last modification time on the client side. That was being calculated incorrectly, since we weren't passing system report entries into the Incidents view (exclude_system_entries = True). This moves over that computation to the server.

Also, this adds a "Modified" column to the Incidents view. I'm theorizing that people might find this useful; possibly more useful than "Created". It could especially be useful as a sort order, so that active Incidents are at the top and older ones fall to the bottom.

NOTE that if we want to remove this DataTables column in the future, we should still keep the server-side piece of this commit, and we should still use the new "last_modified" field in the API to know when an Incident was last modified.