### PR TITLE
prevent duplicate report entries

### DIFF
--- a/src/ims/element/static/field_report.js
+++ b/src/ims/element/static/field_report.js
@@ -81,7 +81,8 @@ function initFieldReportPage() {
             }
         });
         $("#report_entry_add")[0].addEventListener("keydown", function (e) {
-            if ((e.ctrlKey || e.altKey) && e.key === "Enter") {
+            const submitEnabled = !$("#report_entry_submit").hasClass("disabled");
+            if (submitEnabled && (e.ctrlKey || e.altKey) && e.key === "Enter") {
                 submitReportEntry();
             }
         });

--- a/src/ims/element/static/ims.js
+++ b/src/ims/element/static/ims.js
@@ -888,12 +888,13 @@ function submitReportEntry() {
         // Clear the report entry
         $textArea.val("");
         controlHasSuccess($textArea, 1000);
-        // Reset the submit button
+        // Reset the submit button and its "disabled" status
         reportEntryEdited();
     }
 
     function fail() {
         const submitButton = $("#report_entry_submit");
+        submitButton.removeClass("disabled");
         submitButton.removeClass("btn-default");
         submitButton.removeClass("btn-warning");
         submitButton.addClass("btn-danger");
@@ -902,6 +903,9 @@ function submitReportEntry() {
 
     // send a dummy ID to appease the JSON parser in the server
     sendEdits({"report_entries": [{"text": text, "id": -1}]}, ok, fail);
+
+    // Disable the submit button to prevent repeat submissions
+    $("#report_entry_submit").addClass("disabled");
 }
 
 //

--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -111,7 +111,8 @@ function initIncidentPage() {
             }
         });
         $("#report_entry_add")[0].addEventListener("keydown", function (e) {
-            if ((e.ctrlKey || e.altKey) && e.key === "Enter") {
+            const submitEnabled = !$("#report_entry_submit").hasClass("disabled");
+            if (submitEnabled && (e.ctrlKey || e.altKey) && e.key === "Enter") {
                 submitReportEntry();
             }
         });


### PR DESCRIPTION
I was able to reproduce the linked issue by playing with network latency (yay Chrome dev tools). I introduced a 1 second lag on all requests, and found that I was able to hit the "add entry" button several times in quick succession to get duplicate entries. More practically, this also happens when you press and hold "ctrl + enter". This change disables the submit button as soon as the request is fired off, removing those possibilities for duplicates.

Fixes #717