### PR TITLE
remove Responsive DataTabling, tweak some columns

### DIFF
--- a/src/ims/element/incident/incidents_template/template.xhtml
+++ b/src/ims/element/incident/incidents_template/template.xhtml
@@ -165,12 +165,12 @@
     <thead>
     <tr>
       <th>#</th>
-<!--      <th>Created</th>-->
+      <th>Created</th>
       <th>State</th>
       <th>Summary</th>
-      <th>Rangers</th>
-      <th>Location</th>
       <th>Types</th>
+      <th>Location</th>
+      <th>Rangers</th>
       <th>Modified</th>
     </tr>
     </thead>
@@ -178,12 +178,12 @@
     <tfoot>
     <tr>
       <th>#</th>
-<!--      <th>Created</th>-->
+      <th>Created</th>
       <th>State</th>
       <th>Summary</th>
-      <th>Rangers</th>
-      <th>Location</th>
       <th>Types</th>
+      <th>Location</th>
+      <th>Rangers</th>
       <th>Modified</th>
     </tr>
     </tfoot>

--- a/src/ims/element/incident/report_template/template.xhtml
+++ b/src/ims/element/incident/report_template/template.xhtml
@@ -59,7 +59,7 @@
         <input
                 id="field_report_summary" class="form-control input-sm"
                 type="text" inputmode="latin-prose"
-                placeholder="e.g. Someone did a thing at Camp ABC. IMS#123"
+                placeholder="One-line summary. **Pretty-please include an IMS# here**"
                 onchange="editSummary()"
         />
       </div>

--- a/src/ims/element/static/field_reports.js
+++ b/src/ims/element/static/field_reports.js
@@ -138,9 +138,11 @@ function initDataTables() {
             "bottomStart": "info",
             "bottomEnd": "paging",
         },
-        "responsive": {
-            "details": false,
-        },
+        // Responsive is too slow to resize when all FRs are shown.
+        // Decide on this another day.
+        // "responsive": {
+        //     "details": false,
+        // },
         "ajax": {
             // don't use exclude_system_entries here, since the field reports
             // per-user authorization can exclude field reports entirely from

--- a/src/ims/element/static/incidents.js
+++ b/src/ims/element/static/incidents.js
@@ -204,9 +204,11 @@ function initDataTables() {
             "bottomStart": "info",
             "bottomEnd": "paging",
         },
-        "responsive": {
-            "details": false,
-        },
+        // Responsive is too slow to resize when all Incidents are shown.
+        // Decide on this another day.
+        // "responsive": {
+        //     "details": false,
+        // },
         "ajax": {
             "url": dataURL,
             "dataSrc": dataHandler,
@@ -236,14 +238,16 @@ function initDataTables() {
                 "data": "number",
                 "defaultContent": null,
                 "cellType": "th",
+                // "all" class --> very high responsivePriority
             },
-            // {   // 1
-            //     "name": "incident_created",
-            //     "className": "incident_created text-center",
-            //     "data": "created",
-            //     "defaultContent": null,
-            //     "render": renderDate,
-            // },
+            {   // 1
+                "name": "incident_created",
+                "className": "incident_created text-center",
+                "data": "created",
+                "defaultContent": null,
+                "render": renderDate,
+                "responsivePriority": 7,
+            },
             {   // 2
                 "name": "incident_state",
                 "className": "incident_state text-center",
@@ -258,23 +262,9 @@ function initDataTables() {
                 "data": "summary",
                 "defaultContent": "",
                 "render": renderSummary,
+                // "all" class --> very high responsivePriority
             },
             {   // 4
-                "name": "incident_ranger_handles",
-                "className": "incident_ranger_handles",
-                "data": "ranger_handles",
-                "defaultContent": "",
-                "render": renderSafeSorted,
-                "width": "6em",
-            },
-            {   // 5
-                "name": "incident_location",
-                "className": "incident_location",
-                "data": "location",
-                "defaultContent": "",
-                "render": renderLocation,
-            },
-            {   // 6
                 "name": "incident_types",
                 "className": "incident_types",
                 "data": "incident_types",
@@ -283,12 +273,30 @@ function initDataTables() {
                 "width": "5em",
                 "responsivePriority": 4,
             },
+            {   // 5
+                "name": "incident_location",
+                "className": "incident_location",
+                "data": "location",
+                "defaultContent": "",
+                "render": renderLocation,
+                "responsivePriority": 5,
+            },
+            {   // 6
+                "name": "incident_ranger_handles",
+                "className": "incident_ranger_handles",
+                "data": "ranger_handles",
+                "defaultContent": "",
+                "render": renderSafeSorted,
+                "width": "6em",
+                "responsivePriority": 6,
+            },
             {   // 7
                 "name": "incident_last_modified",
                 "className": "incident_last_modified text-center",
                 "data": "last_modified",
                 "defaultContent": null,
                 "render": renderDate,
+                "responsivePriority": 8,
             },
         ],
         "order": [
@@ -302,11 +310,11 @@ function initDataTables() {
                     "Incident:" + eventID + "#" + incident.number,
                 );
             })
-            // row.getElementsByClassName("incident_created")[0]
-            //     .setAttribute(
-            //         "title",
-            //         fullDateTime.format(Date.parse(incident.created)),
-            //     );
+            row.getElementsByClassName("incident_created")[0]
+                .setAttribute(
+                    "title",
+                    fullDateTime.format(Date.parse(incident.created)),
+                );
             row.getElementsByClassName("incident_last_modified")[0]
                 .setAttribute(
                     "title",


### PR DESCRIPTION
Responsive was fun while it lasted... I still might try to bring it back, but it's just prohibitively slow to resize a window when all incidents are being shown for an event.

I'm liking this new selection and ordering of incident table columns. We'll see how it's received.