### PR TITLE
remove "vintage" use, as it doesn't work

### DIFF
--- a/src/ims/directory/clubhouse_db/_dms.py
+++ b/src/ims/directory/clubhouse_db/_dms.py
@@ -173,7 +173,7 @@ class DutyManagementSystem:
             on_site,
             password
         from person
-        where status in ('active', 'inactive', 'vintage', 'auditor')
+        where status in ('active', 'inactive', 'auditor')
         """
         self._log.debug("EXECUTE DMS: {sql}", sql=sql)
         rows = await self.dbpool.runQuery(sql)
@@ -324,5 +324,4 @@ def statusFromID(strValue: str) -> RangerStatus:
     return {
         "active": RangerStatus.active,
         "inactive": RangerStatus.inactive,
-        "vintage": RangerStatus.vintage,
     }.get(strValue, RangerStatus.other)

--- a/src/ims/directory/clubhouse_db/test/dummy.py
+++ b/src/ims/directory/clubhouse_db/test/dummy.py
@@ -87,7 +87,7 @@ class DummyConnectionPool:
             "id, callsign, "
             "email, status, on_site, password "
             "from person where status in "
-            "('active', 'inactive', 'vintage', 'auditor')"
+            "('active', 'inactive', 'auditor')"
         ):
             rows = (fixPassword(p) for p in cannedPersonnel)
             return succeed(rows)  # type: ignore[arg-type]
@@ -153,7 +153,7 @@ cannedPersonnel = (
         5,
         "Tool",
         "tool@example.com",
-        "vintage",
+        "active",
         True,
         "toolpass",
     ),
@@ -161,7 +161,7 @@ cannedPersonnel = (
         6,
         "Tulsa",
         "tulsa@example.com",
-        "vintage",
+        "active",
         True,
         "tulsapass",
     ),

--- a/src/ims/directory/file/_directory.py
+++ b/src/ims/directory/file/_directory.py
@@ -39,7 +39,6 @@ def statusFromID(strValue: str) -> RangerStatus:
     return {
         "active": RangerStatus.active,
         "inactive": RangerStatus.inactive,
-        "vintage": RangerStatus.vintage,
     }.get(strValue, RangerStatus.other)
 
 

--- a/src/ims/directory/file/test/test_directory.py
+++ b/src/ims/directory/file/test/test_directory.py
@@ -120,11 +120,10 @@ class UtilityTests(TestCase):
         for name, status in (
             ("active", RangerStatus.active),
             ("inactive", RangerStatus.inactive),
-            ("vintage", RangerStatus.vintage),
         ):
             self.assertIdentical(statusFromID(name), status)
 
-    @given(text().filter(lambda name: name not in ("active", "inactive", "vintage")))
+    @given(text().filter(lambda name: name not in ("active", "inactive")))
     @settings(max_examples=10)
     def test_statusFromID_unknown(self, name: str) -> None:
         self.assertIdentical(statusFromID(name), RangerStatus.other)

--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -225,7 +225,6 @@ function loadPersonnel(success) {
             // FIXME: better yet: filter based on on-playa state
             switch (record.status) {
                 case "active":
-                case "vintage":
                     break;
                 default:
                     continue;
@@ -572,13 +571,7 @@ function drawRangersToAdd() {
 
 
 function rangerAsString(ranger) {
-    let result = ranger.handle;
-
-    if (ranger.status === "vintage") {
-        result += "*";
-    }
-
-    return result;
+    return ranger.handle;
 }
 
 

--- a/src/ims/model/_ranger.py
+++ b/src/ims/model/_ranger.py
@@ -34,7 +34,6 @@ __all__ = ()
 statusDescriptions = {
     "active": "Active Ranger",
     "inactive": "Inactive Ranger",
-    "vintage": "Vintage Ranger",
     "other": "(Unknown Person Type)",
 }
 
@@ -49,7 +48,6 @@ class RangerStatus(Names):
 
     active = auto()
     inactive = auto()
-    vintage = auto()
 
     other = auto()
 

--- a/src/ims/model/jsons/_ranger.py
+++ b/src/ims/model/jsons/_ranger.py
@@ -86,7 +86,6 @@ class RangerStatusJSONValue(Enum):
 
     active = "active"
     inactive = "inactive"
-    vintage = "vintage"
     other = "(unknown)"
 
 

--- a/src/ims/model/jsons/test/json_helpers.py
+++ b/src/ims/model/jsons/test/json_helpers.py
@@ -178,7 +178,6 @@ def jsonFromRangerStatus(status: RangerStatus) -> str:
     return {
         RangerStatus.active: "active",
         RangerStatus.inactive: "inactive",
-        RangerStatus.vintage: "vintage",
         RangerStatus.other: "(unknown)",
     }[status]
 


### PR DESCRIPTION
Vintage is no longer a Ranger status, so it never shows up. We could start reading the new Vintage attribute instead, but no one has asked for that yet.

fixes #367