### PR TITLE
add "created" timestamp to incident page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,17 +21,28 @@ Each month below should look like the following, using the same ordering for the
 
 <!-- TODO: document keyboard shortcut updates, once they've settled down a bit -->
 
+### Changed
+
+- Reordered columns on Incidents page for improved readability and mobile experience. The summary field is now much farther left. We also added a "last modified" column, which may or may not prove useful for people. https://github.com/burningmantech/ranger-ims-server/pull/1589 https://github.com/burningmantech/ranger-ims-server/pull/1595
+
 ### Added
 
 - Started allowing searches using regular expressions on the Incidents and Field Reports pages, mostly to support "OR"-based queries. https://github.com/burningmantech/ranger-ims-server/issues/1570
 - Created the ability to have a search query as part of an Incidents or Field Reports page URL. This allows bookmarking. https://github.com/burningmantech/ranger-ims-server/issues/1570
 - Put all the table filters (state, type, rows, days-ago) into the URLs, making all of those bookmarkable, in addition to search. https://github.com/burningmantech/ranger-ims-server/issues/1570
 - Converted the "show incident type" dropdown into a multiselect, allowing filtering the Incidents page to any number of Incident Types. https://github.com/burningmantech/ranger-ims-server/issues/1581
+- Added "created" timestamp to Incident page, where "priority" used to be. https://github.com/burningmantech/ranger-ims-server/pull/1599
+- Added team-based access control, e.g. to allow all members of Council to have year-round access. https://github.com/burningmantech/ranger-ims-server/pull/1587
+- Created links in the navbar to the current event's Incidents and Field Reports pages. https://github.com/burningmantech/ranger-ims-server/pull/1580
 
 ### Removed
 
 - Dropped Incident "priority" from the UI, since almost no one was using it. https://github.com/burningmantech/ranger-ims-server/issues/1574
 - Removed the "show all" keyboard shortcut for Incidents and Field Reports pages, since the new bookmarkable filtered views make such a shortcut unnecessary. https://github.com/burningmantech/ranger-ims-server/issues/1570
+
+### Fixed
+
+- Prevented duplicate report entries from getting saved during periods of network latency. https://github.com/burningmantech/ranger-ims-server/pull/1593
 
 ## 2025-01
 

--- a/src/ims/element/incident/incident_template/template.xhtml
+++ b/src/ims/element/incident/incident_template/template.xhtml
@@ -21,16 +21,16 @@
     </div>
   </div>
 
-  <!-- Incident number, state -->
+  <!-- Incident number, state, created -->
 
   <div class="row py-1">
-    <div class="col-sm-6 py-1">
+    <div class="col-sm-4 py-1">
       <div class="input-group">
         <label class="control-label input-group-text">IMS #</label>
         <span id="incident_number" class="form-control form-control-static"/>
       </div>
     </div>
-    <div class="col-sm-6 py-1">
+    <div class="col-sm-4 py-1">
       <div class="input-group">
         <label for="incident_state" class="control-label input-group-text">State</label>
         <select
@@ -44,6 +44,12 @@
           <option value="on_scene">On Scene</option>
           <option value="closed">Closed</option>
         </select>
+      </div>
+    </div>
+    <div class="col-sm-4 py-1">
+      <div class="input-group">
+        <label class="control-label input-group-text">Created</label>
+        <span id="created_datetime" class="form-control form-control-static"/>
       </div>
     </div>
   </div>

--- a/src/ims/element/static/ims.js
+++ b/src/ims/element/static/ims.js
@@ -637,6 +637,15 @@ const shortTime = new Intl.DateTimeFormat(undefined, {
     // timeZone not specified; will use user's timezone
 });
 
+// e.g. "19:21"
+const shortTimeSec = new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    hour12: false,
+    minute: "numeric",
+    second: "numeric",
+    // timeZone not specified; will use user's timezone
+});
+
 // e.g. "Thu, Aug 29, 2024, 19:11:04 EDT"
 const fullDateTime = new Intl.DateTimeFormat(undefined, {
     weekday: "short",

--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -395,6 +395,7 @@ function drawIncidentFields() {
     drawTitle();
     drawNumber();
     drawState();
+    drawCreated();
     drawPriority();
     drawSummary();
     drawRangers();
@@ -473,6 +474,20 @@ function drawState() {
     );
 }
 
+
+//
+// Populate created datetime
+//
+
+function drawCreated() {
+    const date = incident.created;
+    if (date == null) {
+        return;
+    }
+    const d = Date.parse(date);
+    $("#created_datetime").text(`${shortDate.format(d)} ${shortTimeSec.format(d)}`);
+    $("#created_datetime").attr("title", fullDateTime.format(d));
+}
 
 //
 // Populate incident priority


### PR DESCRIPTION
we had unused space with the removal of "priority", and "created" time seems like a good thing to fill it with