### PR TITLE
nag user to supply an incident type before closing an incident

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Each month below should look like the following, using the same ordering for the
 - Added "created" timestamp to Incident page, where "priority" used to be. https://github.com/burningmantech/ranger-ims-server/pull/1599
 - Added team-based access control, e.g. to allow all members of Council to have year-round access. https://github.com/burningmantech/ranger-ims-server/pull/1587
 - Created links in the navbar to the current event's Incidents and Field Reports pages. https://github.com/burningmantech/ranger-ims-server/pull/1580
+- Added popup alert when user tries to close an incident that doesn't have any incident type. https://github.com/burningmantech/ranger-ims-server/pull/1600
 
 ### Removed
 

--- a/src/ims/element/static/admin_types.js
+++ b/src/ims/element/static/admin_types.js
@@ -67,8 +67,10 @@ function loadIncidentTypes(success) {
         window.alert(message);
     }
 
-    jsonRequest(url_incidentTypes, null, okVisible, fail);
-    jsonRequest(url_incidentTypes + "?hidden=true", null, okAll, fail);
+    const headers = {"Cache-Control": "no-cache"};
+
+    jsonRequest(url_incidentTypes, null, okVisible, fail, headers);
+    jsonRequest(url_incidentTypes + "?hidden=true", null, okAll, fail, headers);
 }
 
 

--- a/src/ims/element/static/ims.js
+++ b/src/ims/element/static/ims.js
@@ -178,7 +178,7 @@ function compareReportEntries(a, b) {
 // Request making
 //
 
-function jsonRequest(url, jsonOut, success, error) {
+function jsonRequest(url, jsonOut, success, error, headers) {
     function ok(data, status, xhr) {
         if (success) {
             success(data, status, xhr);
@@ -208,6 +208,9 @@ function jsonRequest(url, jsonOut, success, error) {
         "success": ok,
         "error": fail,
     };
+    if (headers) {
+        args["headers"] = headers;
+    }
 
     if (jsonOut) {
         const jsonText = JSON.stringify(jsonOut);

--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -867,7 +867,20 @@ function sendEdits(edits, success, error) {
 
 
 function editState() {
-    editFromElement($("#incident_state"), "state");
+    const $state = $("#incident_state");
+
+    if ($state.val() === "closed" && (incident.incident_types??[]).length === 0) {
+        window.alert(
+            "Closing out this incident?\n"+
+            "Please add an incident type!\n\n" +
+            "Special cases:\n" +
+            "    Junk: for erroneously-created Incidents\n" +
+            "    Admin: for administrative information, i.e. not Incidents at all\n\n" +
+            "See the Incident Types help link for more details.\n"
+        );
+    }
+
+    editFromElement($state, "state");
 }
 
 


### PR DESCRIPTION
unrelated thing: don't cache incident types when on the incident types admin page, since then new types don't show up after you add them.

fixes #199