### PR TITLE
use hotkey to jump to add entry, enhance shortcut help

### DIFF
--- a/src/ims/element/incident/incident_template/template.xhtml
+++ b/src/ims/element/incident/incident_template/template.xhtml
@@ -14,8 +14,9 @@
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
         </div>
         <div class="modal-body">
-          <code>n</code>: create new Incident <br/>
-          <code>h</code>: toggle showing system-generated history <br/>
+          <code>n</code>: create (n)ew Incident <br/>
+          <code>a</code>: jump to (a)dd new report text<br/>
+          <code>h</code>: toggle showing system-generated (h)istory <br/>
         </div>
       </div>
     </div>
@@ -248,7 +249,7 @@
                   id="report_entry_add"
                   class="form-control no-print"
                   rows="3"
-                  placeholder="Additional report text..."
+                  placeholder="Press &quot;a&quot; to add report text"
                   autofocus=""
                   onchange="reportEntryEdited()"
           />

--- a/src/ims/element/incident/incidents_template/template.xhtml
+++ b/src/ims/element/incident/incidents_template/template.xhtml
@@ -16,7 +16,7 @@
         <div class="modal-body">
           <p class="mt-2 mb-0">Keyboard shortcuts</p>
           <ul>
-            <li><code>n</code>: create new Incident <br/></li>
+            <li><code>n</code>: create (n)ew Incident <br/></li>
             <li><code>/</code>: jump to search field <br/></li>
           </ul>
           <p class="mt-2 mb-0">In the search field</p>
@@ -150,7 +150,7 @@
                   id="search_input"
                   type="search"
                   class="form-control search-box"
-                  placeholder="Search"
+                  placeholder="Press &quot; ⁄ &quot; to search"
                   inputmode="latin"
                   autocomplete="off"
                   aria-controls="queue_table"

--- a/src/ims/element/incident/report_template/template.xhtml
+++ b/src/ims/element/incident/report_template/template.xhtml
@@ -14,8 +14,9 @@
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
         </div>
         <div class="modal-body">
-          <code>n</code>: create new Field Report <br/>
-          <code>h</code>: toggle showing system-generated history <br/>
+          <code>n</code>: create (n)ew Field Report <br/>
+          <code>a</code>: jump to (a)dd new report text<br/>
+          <code>h</code>: toggle showing system-generated (h)istory <br/>
         </div>
       </div>
     </div>
@@ -144,7 +145,7 @@
                     id="report_entry_add"
                     class="form-control no-print input-sm"
                     rows="12"
-                    placeholder="Additional report text..."
+                    placeholder="Press &quot;a&quot; to add report text"
                     autofocus=""
                     onchange="reportEntryEdited()"
             />

--- a/src/ims/element/incident/reports_template/template.xhtml
+++ b/src/ims/element/incident/reports_template/template.xhtml
@@ -16,7 +16,7 @@
         <div class="modal-body">
           <p class="mt-2 mb-0">Keyboard shortcuts</p>
           <ul>
-            <li><code>n</code>: create new Field Report <br/></li>
+            <li><code>n</code>: create (n)ew Field Report <br/></li>
             <li><code>/</code>: jump to search field <br/><br/></li>
           </ul>
           <p class="mt-2 mb-0">In the search field</p>
@@ -110,7 +110,7 @@
                 id="search_input"
                 type="search"
                 class="form-control search-box"
-                placeholder="Search"
+                placeholder="Press &quot; ⁄ &quot; to search"
                 inputmode="latin"
                 autocomplete="off"
                 aria-controls="field_reports_table"

--- a/src/ims/element/page/_page.py
+++ b/src/ims/element/page/_page.py
@@ -74,7 +74,8 @@ class Page(Element):
 
             if name == "dataTables":
                 add("dataTablesBootstrap")
-                add("dataTablesResponsive")
+                # Responsive is currently unused. See incidents.js as well.
+                # add("dataTablesResponsive")
 
         # All pages use Bootstrap
         add("bootstrap")

--- a/src/ims/element/static/field_report.js
+++ b/src/ims/element/static/field_report.js
@@ -66,6 +66,13 @@ function initFieldReportPage() {
             if (e.key === "?") {
                 $("#helpModal").modal("toggle");
             }
+            // a --> jump to add a new report entry
+            if (e.key === "a") {
+                e.preventDefault();
+                // Scroll to report_entry_add field
+                $("html, body").animate({scrollTop: $("#report_entry_add").offset().top}, 500);
+                $("#report_entry_add").focus();
+            }
             // h --> toggle showing system entries
             if (e.key.toLowerCase() === "h") {
                 document.getElementById("history_checkbox").click();

--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -27,13 +27,9 @@ function initIncidentPage() {
         loadIncidentTypes(drawIncidentTypesToAdd);
         loadAllFieldReports(renderFieldReportData);
 
-        // for a new incident
+        // for a new incident, jump to summary field
         if (incident.number == null) {
             $("#incident_summary").focus();
-        } else {
-            // Scroll to report_entry_add field
-            $("html, body").animate({scrollTop: $("#report_entry_add").offset().top}, 500);
-            $("#report_entry_add").focus();
         }
 
         // Warn the user if they're about to navigate away with unsaved text.
@@ -95,6 +91,13 @@ function initIncidentPage() {
             // ? --> show help modal
             if (e.key === "?") {
                 $("#helpModal").modal("toggle");
+            }
+            // a --> jump to add a new report entry
+            if (e.key === "a") {
+                e.preventDefault();
+                // Scroll to report_entry_add field
+                $("html, body").animate({scrollTop: $("#report_entry_add").offset().top}, 500);
+                $("#report_entry_add").focus();
             }
             // h --> toggle showing system entries
             if (e.key.toLowerCase() === "h") {


### PR DESCRIPTION
the automated jump to "add entry text" textbox has bugged me for a while, as it's weird behavior that's undesirable much of the time. This instead changes that so the the user can tap "a" after opening an incident to jump to that field.

#1482 
fixes #1444