### PR TITLE
fully swap over to async/await in JavaScript

### DIFF
--- a/src/ims/element/static/admin_streets.js
+++ b/src/ims/element/static/admin_streets.js
@@ -20,11 +20,9 @@
 
 async function initPage() {
     detectTouchDevice();
-    try {
-        await loadStreets();
+    const {err} = await loadStreets();
+    if (err == null) {
         drawStreets();
-    } catch (err) {
-        // do nothing
     }
 }
 
@@ -32,14 +30,15 @@ async function initPage() {
 let streets = null;
 
 async function loadStreets() {
-    try {
-        streets = await jsonRequestAsync(url_streets, null);
-    } catch (err) {
-        const message = `Failed to load streets:\n${JSON.stringify(err)}`;
+    let {json, err} = await fetchJsonNoThrow(url_streets);
+    if (err != null) {
+        const message = `Failed to load streets: ${err}`;
         console.error(message);
         window.alert(message);
-        throw err;
+        return {err: message};
     }
+    streets = json;
+    return {err: null};
 }
 
 
@@ -112,11 +111,10 @@ function removeStreet(sender) {
 }
 
 
-async function sendStreets(edits, success, error) {
-    try {
-        await jsonRequestAsync(url_streets, edits);
-    } catch (err) {
-        const message = `Failed to edit streets:\n${JSON.stringify(err)}`;
+async function sendStreets(edits) {
+    let {err} = await fetchJsonNoThrow(url_streets, edits);
+    if (err != null) {
+        const message = `Failed to edit streets:\n${err}`;
         console.log(message);
         window.alert(message);
     }

--- a/src/ims/element/static/field_reports.js
+++ b/src/ims/element/static/field_reports.js
@@ -17,45 +17,44 @@
 // Initialize UI
 //
 
-function initFieldReportsPage() {
-    function loadedBody() {
-        disableEditing();
-        initFieldReportsTable();
+async function initFieldReportsPage() {
 
-        // Keyboard shortcuts
-        document.addEventListener("keydown", function(e) {
-            // No shortcuts when an input field is active
-            if (document.activeElement !== document.body) {
-                return;
-            }
-            // No shortcuts when ctrl, alt, or meta is being held down
-            if (e.altKey || e.ctrlKey || e.metaKey) {
-                return;
-            }
-            // ? --> show help modal
-            if (e.key === "?") {
-                $("#helpModal").modal("toggle");
-            }
-            // / --> jump to search box
-            if (e.key === "/") {
-                // don't immediately input a "/" into the search box
-                e.preventDefault();
-                document.getElementById("search_input").focus();
-            }
-            // n --> new incident
-            if (e.key.toLowerCase() === "n") {
-                document.getElementById("new_field_report").click();
-            }
-            // TODO: should there also be a shortcut to show the default filters?
-        });
-        document.getElementById("helpModal").addEventListener("keydown", function(e) {
-            if (e.key === "?") {
-                $("#helpModal").modal("toggle");
-            }
-        });
-    }
+    await loadBody();
 
-    loadBody(loadedBody);
+    disableEditing();
+    initFieldReportsTable();
+
+    // Keyboard shortcuts
+    document.addEventListener("keydown", function(e) {
+        // No shortcuts when an input field is active
+        if (document.activeElement !== document.body) {
+            return;
+        }
+        // No shortcuts when ctrl, alt, or meta is being held down
+        if (e.altKey || e.ctrlKey || e.metaKey) {
+            return;
+        }
+        // ? --> show help modal
+        if (e.key === "?") {
+            $("#helpModal").modal("toggle");
+        }
+        // / --> jump to search box
+        if (e.key === "/") {
+            // don't immediately input a "/" into the search box
+            e.preventDefault();
+            document.getElementById("search_input").focus();
+        }
+        // n --> new incident
+        if (e.key.toLowerCase() === "n") {
+            document.getElementById("new_field_report").click();
+        }
+        // TODO: should there also be a shortcut to show the default filters?
+    });
+    document.getElementById("helpModal").addEventListener("keydown", function(e) {
+        if (e.key === "?") {
+            $("#helpModal").modal("toggle");
+        }
+    });
 }
 
 
@@ -82,7 +81,8 @@ function initFieldReportsTable() {
     fieldReportChannel.onmessage = function (e) {
         if (e.data["update_all"]) {
             console.log("Reloading the whole table to be cautious, as an SSE was missed")
-            fieldReportsTable.ajax.reload(clearErrorMessage);
+            fieldReportsTable.ajax.reload();
+            clearErrorMessage();
             return;
         }
 
@@ -99,7 +99,8 @@ function initFieldReportsTable() {
         //  Field Reports for which they're not authorized, and those errors
         //  show up in the browser console. I'd like to find a way to avoid
         //  bringing those errors into the console constantly.
-        fieldReportsTable.ajax.reload(clearErrorMessage);
+        fieldReportsTable.ajax.reload();
+        clearErrorMessage();
     }
 }
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.13"
 
 [[package]]
@@ -458,7 +459,6 @@ wheels = [
 
 [[package]]
 name = "ranger-ims-server"
-version = "0.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "arrow" },


### PR DESCRIPTION
also use the standard Fetch API rather than jquery ajax

This was a pretty big change, but it makes the code a lot simpler. The callbacks within callbacks within callbacks were a nightmare when trying to reason through the code. async/await lets you pretty much just read top to bottom.

I opted against throwing errors (/using Promise.reject) in favor of returning errors instead. It's prettier than having try-catches all over the place, or maybe that's just my opinion as a Gopher.

https://github.com/burningmantech/ranger-ims-server/issues/1602