### PR TITLE
allow case insensitive login, add login tests

### DIFF
--- a/src/ims/directory/clubhouse_db/test/test_directory.py
+++ b/src/ims/directory/clubhouse_db/test/test_directory.py
@@ -18,10 +18,50 @@
 Tests for L{ims.directory.clubhouse_db._directory}.
 """
 
+from ims.directory import IMSUser
+from ims.directory.clubhouse_db import DMSDirectory
+from ims.directory.clubhouse_db._dms import Position, Team
 from ims.ext.trial import TestCase
+from ims.model import Ranger, RangerStatus
 
 
 __all__ = ()
+
+
+def _ranger_alpha() -> Ranger:
+    return Ranger(
+        handle="Alpha",
+        status=RangerStatus.active,
+        email=frozenset(["alpha@example.com"]),
+        onsite=False,
+        directoryID=None,
+    )
+
+
+def _ranger_beta() -> Ranger:
+    return Ranger(
+        handle="Beta",
+        status=RangerStatus.active,
+        email=frozenset(["beta@example.com"]),
+        onsite=True,
+        directoryID=None,
+    )
+
+
+def _position_delta() -> Position:
+    return Position(
+        positionID="ddd",
+        name="Delta",
+        members={_ranger_alpha()},
+    )
+
+
+def _team_upsilon() -> Team:
+    return Team(
+        teamID="uuu",
+        name="Upsilon",
+        members={_ranger_beta()},
+    )
 
 
 class DMSDirectoryTests(TestCase):
@@ -35,6 +75,39 @@ class DMSDirectoryTests(TestCase):
     test_personnel.todo = "unimplemented"  # type: ignore[attr-defined]
 
     def test_lookupUser(self) -> None:
-        raise NotImplementedError()
+        def lookup(search: str) -> IMSUser | None:
+            return DMSDirectory._lookupUser(
+                search,
+                (_ranger_alpha(), _ranger_beta()),
+                (_position_delta(),),
+                (_team_upsilon(),),
+            )
 
-    test_lookupUser.todo = "unimplemented"  # type: ignore[attr-defined]
+        # Case-insensitive matching against handles and email addresses
+        self.assertIsNotNone(lookup("alpha"))
+        self.assertIsNotNone(lookup("Alpha"))
+        self.assertIsNotNone(lookup("beta@example.com"))
+        self.assertIsNotNone(lookup("ALPHA@exAMple.com"))
+
+        # Failures to match against handle or email address
+        self.assertIsNone(lookup("NotARanger@example.com"))
+        self.assertIsNone(lookup("BetaWithSuffix"))
+
+        # Now check the various fields that come back, including
+        # positions and teams set up at the top of this test file.
+        alpha = lookup("alpha")
+        beta = lookup("BETA@EXAMPLE.COM")
+        self.assertIsNotNone(alpha)
+        # to appease mypy
+        assert alpha is not None
+        self.assertEqual(alpha.uid, "Alpha")
+        self.assertEqual(alpha.shortNames, ("Alpha",))
+        self.assertEqual(alpha.onsite, False)
+        self.assertEqual(alpha.groups, ("Delta",))
+        self.assertEqual(alpha.teams, ())
+        self.assertIsNotNone(beta)
+        # to appease mypy
+        assert beta is not None
+        self.assertEqual(beta.onsite, True)
+        self.assertEqual(beta.groups, ())
+        self.assertEqual(beta.teams, ("Upsilon",))


### PR DESCRIPTION
The 2024 Tech AARs asked for case insensitive login, as we already have with Clubhouse. I don't totally love this, because the specification for SMTP clearly says
"The local-part of a mailbox MUST BE treated as case sensitive" even though most mail servers treat it as case insensitive in practice.

My preference would be for us to only treat the part after the "@" as case insensitive, but whatever we do, it should align with Clubhouse.

https://www.ietf.org/rfc/rfc2821.txt