### PR TITLE
require event IDs to match ^[\w-]+$

### DIFF
--- a/src/ims/model/strategies.py
+++ b/src/ims/model/strategies.py
@@ -23,11 +23,13 @@ from datetime import UTC
 from datetime import datetime as DateTime
 from datetime import timedelta as TimeDelta
 from datetime import timezone as TimeZone
+from string import ascii_letters
 from typing import Any, cast
 
 from hypothesis.strategies import (
     SearchStrategy,
     booleans,
+    characters,
     composite,
     dictionaries,
     emails,
@@ -248,7 +250,23 @@ def events(draw: Callable[..., Any]) -> Event:
     """
     Strategy that generates :class:`Event` values.
     """
-    return Event(id=draw(text(min_size=1)))
+    # The Event ID can consist of characters that match
+    # \w_-
+
+    allow_letters = [*list(ascii_letters), "-", "_"]
+    return Event(
+        id=draw(
+            text(
+                min_size=1,
+                alphabet=characters(
+                    # Include the digits 0-9 too
+                    min_codepoint=0x30,
+                    max_codepoint=0x39,
+                    include_characters=allow_letters,
+                ),
+            )
+        )
+    )
 
 
 @composite

--- a/src/ims/store/_db.py
+++ b/src/ims/store/_db.py
@@ -25,6 +25,7 @@ from datetime import UTC
 from datetime import datetime as DateTime
 from json import loads
 from pathlib import Path
+from re import search as reSearch
 from textwrap import dedent
 from types import MappingProxyType
 from typing import Any, ClassVar, NoReturn, TypeVar, cast
@@ -366,6 +367,14 @@ class DatabaseStore(IMSDataStore):
         """
         See :meth:`IMSDataStore.createEvent`.
         """
+        # Require basic cleanliness for EventID, since it's used in IMS URLs
+        # and in filesystem directory paths.
+        eventIdPattern = r"^[\w-]+$"
+        if not reSearch(eventIdPattern, event.id):
+            raise ValueError(
+                f"wanted EventID to match '{eventIdPattern}', got '{event.id}'"
+            )
+
         await self.runOperation(self.query.createEvent, {"eventID": event.id})
 
         self._log.info(

--- a/src/ims/store/test/event.py
+++ b/src/ims/store/test/event.py
@@ -68,7 +68,7 @@ class DataStoreEventTests(DataStoreTests):
         """
         :meth:`IMSDataStore.createEvent` creates the given event.
         """
-        for eventName in ("Foo", "Foo Bar"):
+        for eventName in ("Foo", "Foo-Bar"):
             event = Event(id=eventName)
 
             store = await self.store()

--- a/src/ims/store/test/street.py
+++ b/src/ims/store/test/street.py
@@ -40,7 +40,7 @@ class DataStoreConcentricStreetTests(DataStoreTests):
         """
         for event, streetID, streetName in (
             (Event(id="Foo"), "A", "Alpha"),
-            (Event(id="Foo Bar"), "B", "Bravo"),
+            (Event(id="Foo-Bar"), "B", "Bravo"),
             (Event(id="XYZZY"), "C", "Charlie"),
         ):
             store = await self.store()
@@ -61,7 +61,7 @@ class DataStoreConcentricStreetTests(DataStoreTests):
         """
         for event, streetID, streetName in (
             (Event(id="Foo"), "A", "Alpha"),
-            (Event(id="Foo Bar"), "B", "Bravo"),
+            (Event(id="Foo-Bar"), "B", "Bravo"),
             (Event(id="XYZZY"), "C", "Charlie"),
         ):
             store = await self.store()


### PR DESCRIPTION
Before this change, event IDs could be totally arbitrary strings. That could make for ugly URLs. Plus, for the work I'm doing now to support file attachments, I need to be able to use the event ID as part of a local filesystem path. That means excluding invalid characters like "/" or "$" or "%". Spaces are nasty too.

Since we've only ever made event IDs that match this pattern anyway, I figure we should just enforce it as a rule.

https://github.com/burningmantech/ranger-ims-server/issues/7