### PR TITLE
make lastModified field required

### DIFF
--- a/src/ims/model/_incident.py
+++ b/src/ims/model/_incident.py
@@ -23,7 +23,7 @@ Incident
 from collections.abc import Iterable, Sequence
 from datetime import datetime as DateTime
 
-from attrs import converters, field, frozen
+from attrs import field, frozen
 
 from ims.ext.attr import sorted_tuple
 
@@ -53,9 +53,7 @@ class Incident(ReplaceMixIn):
     eventID: str
     number: int
     created: DateTime = field(converter=normalizeDateTime)
-    lastModified: DateTime | None = field(
-        converter=converters.optional(normalizeDateTime)
-    )
+    lastModified: DateTime = field(converter=normalizeDateTime)
     state: IncidentState
     priority: IncidentPriority
     summary: str | None


### PR DESCRIPTION
I'm not sure why I had it as optional before, but all the tests pass now with it being required.

https://github.com/burningmantech/ranger-ims-server/pull/1589#discussion_r1972446111