### PR TITLE
set a lastModified time on incident creation

### DIFF
--- a/src/ims/application/_api.py
+++ b/src/ims/application/_api.py
@@ -424,6 +424,7 @@ class APIApplication:
 
         json[IncidentJSONKey.number.value] = 0
         json[IncidentJSONKey.created.value] = jsonNow
+        json[IncidentJSONKey.lastModified.value] = jsonNow
 
         # If not provided, set JSON event, state to new, priority to normal
 


### PR DESCRIPTION
this is a necessary followup to
https://github.com/burningmantech/ranger-ims-server/pull/1616

prior to this PR, new incident creation would fail on converting a None datetime