### PR TITLE
add REPORT_ENTRY.ATTACHED_FILE, fix foreign key bug

### DIFF
--- a/src/ims/store/mysql/_store.py
+++ b/src/ims/store/mysql/_store.py
@@ -100,7 +100,7 @@ class DataStore(DatabaseStore):
 
     _log: ClassVar[Logger] = Logger()
 
-    schemaVersion: ClassVar[int] = 9
+    schemaVersion: ClassVar[int] = 10
     schemaBasePath: ClassVar[Path] = Path(__file__).parent / "schema"
     sqlFileExtension: ClassVar[str] = "mysql"
 

--- a/src/ims/store/mysql/schema/10-from-9.mysql
+++ b/src/ims/store/mysql/schema/10-from-9.mysql
@@ -1,0 +1,23 @@
+/* This migration fixes an FK and adds the new ATTACHED_FILE column. */
+
+/* Firstly, fix up a foreign key on FIELD_REPORT__REPORT_ENTRY, which
+   may still reference the renamed "INCIDENT_REPORT" table. */
+
+alter table `FIELD_REPORT__REPORT_ENTRY`
+    drop foreign key if exists `INCIDENT_REPORT__REPORT_ENTRY_ibfk_2`;
+alter table `FIELD_REPORT__REPORT_ENTRY`
+    drop foreign key if exists `FIELD_REPORT__REPORT_ENTRY_ibfk_2`;
+
+alter table `FIELD_REPORT__REPORT_ENTRY`
+    add constraint `FIELD_REPORT__REPORT_ENTRY___FIELD_REPORT_FK`
+        foreign key if not exists (`EVENT`, `FIELD_REPORT_NUMBER`) references `FIELD_REPORT` (`EVENT`, `NUMBER`);
+
+/* Add support for file attachments */
+
+alter table `REPORT_ENTRY`
+    add column `ATTACHED_FILE` varchar(128)
+;
+
+/* Update schema version */
+
+update `SCHEMA_INFO` set `VERSION` = 10;

--- a/src/ims/store/mysql/schema/10.mysql
+++ b/src/ims/store/mysql/schema/10.mysql
@@ -1,0 +1,163 @@
+create table SCHEMA_INFO (
+    VERSION smallint not null
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+insert into SCHEMA_INFO (VERSION) values (10);
+
+
+create table EVENT (
+    ID   integer      not null auto_increment,
+    NAME varchar(128) not null,
+
+    primary key (ID),
+    unique key (NAME)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+create table CONCENTRIC_STREET (
+    EVENT integer      not null,
+    ID    varchar(16)  not null,
+    NAME  varchar(128) not null,
+
+    primary key (EVENT, ID)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+create table INCIDENT_TYPE (
+    ID     integer      not null auto_increment,
+    NAME   varchar(128) not null,
+    HIDDEN boolean      not null,
+
+    primary key (ID),
+    unique key (NAME)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+insert into INCIDENT_TYPE (NAME, HIDDEN) values ('Admin', 0);
+insert into INCIDENT_TYPE (NAME, HIDDEN) values ('Junk' , 0);
+
+
+create table REPORT_ENTRY (
+    ID        integer     not null auto_increment,
+    AUTHOR    varchar(64) not null,
+    TEXT      text        not null,
+    CREATED   double      not null,
+    GENERATED boolean     not null,
+    STRICKEN  boolean     not null,
+
+    ATTACHED_FILE varchar(128),
+
+    -- FIXME: AUTHOR is an external non-primary key.
+    -- Primary key is DMS Person ID.
+
+    primary key (ID)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+create table INCIDENT (
+    EVENT    integer  not null,
+    NUMBER   integer  not null,
+    CREATED  double   not null,
+    PRIORITY tinyint  not null,
+
+    STATE enum(
+        'new', 'on_hold', 'dispatched', 'on_scene', 'closed'
+    ) not null,
+
+    SUMMARY varchar(1024),
+
+    LOCATION_NAME          varchar(1024),
+    LOCATION_CONCENTRIC    varchar(64),
+    LOCATION_RADIAL_HOUR   tinyint,
+    LOCATION_RADIAL_MINUTE tinyint,
+    LOCATION_DESCRIPTION   varchar(1024),
+
+    foreign key (EVENT) references EVENT(ID),
+
+    foreign key (EVENT, LOCATION_CONCENTRIC)
+    references CONCENTRIC_STREET(EVENT, ID),
+
+    primary key (EVENT, NUMBER)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+create table INCIDENT__RANGER (
+    EVENT           integer     not null,
+    INCIDENT_NUMBER integer     not null,
+    RANGER_HANDLE   varchar(64) not null,
+
+    foreign key (EVENT) references EVENT(ID),
+    foreign key (EVENT, INCIDENT_NUMBER) references INCIDENT(EVENT, NUMBER),
+
+    -- FIXME: RANGER_HANDLE is an external non-primary key.
+    -- Primary key is DMS Person ID.
+
+    primary key (EVENT, INCIDENT_NUMBER, RANGER_HANDLE)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+create table INCIDENT__INCIDENT_TYPE (
+    EVENT           integer not null,
+    INCIDENT_NUMBER integer not null,
+    INCIDENT_TYPE   integer not null,
+
+    foreign key (EVENT) references EVENT(ID),
+    foreign key (EVENT, INCIDENT_NUMBER) references INCIDENT(EVENT, NUMBER),
+    foreign key (INCIDENT_TYPE) references INCIDENT_TYPE(ID),
+
+    primary key (EVENT, INCIDENT_NUMBER, INCIDENT_TYPE)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+create table INCIDENT__REPORT_ENTRY (
+    EVENT           integer not null,
+    INCIDENT_NUMBER integer not null,
+    REPORT_ENTRY    integer not null,
+
+    foreign key (EVENT) references EVENT(ID),
+    foreign key (EVENT, INCIDENT_NUMBER) references INCIDENT(EVENT, NUMBER),
+    foreign key (REPORT_ENTRY) references REPORT_ENTRY(ID),
+
+    primary key (EVENT, INCIDENT_NUMBER, REPORT_ENTRY)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+create table EVENT_ACCESS (
+    EVENT      integer      not null,
+    EXPRESSION varchar(128) not null,
+
+    MODE     enum ('read', 'write', 'report') not null,
+    VALIDITY enum ('always', 'onsite') not null default 'always',
+
+    foreign key (EVENT) references EVENT(ID),
+
+    primary key (EVENT, EXPRESSION)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+create table FIELD_REPORT (
+    EVENT   integer  not null,
+    NUMBER  integer  not null,
+    CREATED double   not null,
+
+    SUMMARY         varchar(1024),
+    INCIDENT_NUMBER integer,
+
+    foreign key (EVENT) references EVENT(ID),
+    foreign key (EVENT, INCIDENT_NUMBER) references INCIDENT(EVENT, NUMBER),
+
+    primary key (EVENT, NUMBER)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+create table FIELD_REPORT__REPORT_ENTRY (
+    EVENT                  integer not null,
+    FIELD_REPORT_NUMBER    integer not null,
+    REPORT_ENTRY           integer not null,
+
+    foreign key (EVENT) references EVENT(ID),
+    foreign key (EVENT, FIELD_REPORT_NUMBER)
+        references FIELD_REPORT(EVENT, NUMBER),
+    foreign key (REPORT_ENTRY) references REPORT_ENTRY(ID),
+
+    primary key (EVENT, FIELD_REPORT_NUMBER, REPORT_ENTRY)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/ims/store/mysql/test/test_store_core.py
+++ b/src/ims/store/mysql/test/test_store_core.py
@@ -144,7 +144,7 @@ class DataStoreCoreTests(AsynchronousTestCase):
         self.assertEqual(
             dedent(
                 """
-                Version: 9
+                Version: 10
                 CONCENTRIC_STREET:
                   1: EVENT(int) not null
                   2: ID(varchar(16)) not null
@@ -202,6 +202,7 @@ class DataStoreCoreTests(AsynchronousTestCase):
                   4: CREATED(double) not null
                   5: GENERATED(tinyint) not null
                   6: STRICKEN(tinyint) not null
+                  7: ATTACHED_FILE(varchar(128)) := NULL
                 SCHEMA_INFO:
                   1: VERSION(smallint) not null
                 """[1:]

--- a/src/ims/store/sqlite/_store.py
+++ b/src/ims/store/sqlite/_store.py
@@ -56,7 +56,7 @@ class DataStore(DatabaseStore):
 
     _log: ClassVar[Logger] = Logger()
 
-    schemaVersion: ClassVar[int] = 6
+    schemaVersion: ClassVar[int] = 7
     schemaBasePath: ClassVar[Path] = Path(__file__).parent / "schema"
     sqlFileExtension: ClassVar[str] = "sqlite"
 

--- a/src/ims/store/sqlite/schema/7-from-6.sqlite
+++ b/src/ims/store/sqlite/schema/7-from-6.sqlite
@@ -1,0 +1,9 @@
+-- Add support for file attachments
+
+alter table REPORT_ENTRY
+    add column ATTACHED_FILE text
+;
+
+-- Update schema version
+
+update SCHEMA_INFO set VERSION = 7;

--- a/src/ims/store/sqlite/schema/7.sqlite
+++ b/src/ims/store/sqlite/schema/7.sqlite
@@ -1,0 +1,192 @@
+create table SCHEMA_INFO (
+    VERSION integer not null
+);
+
+insert into SCHEMA_INFO (VERSION) values (7);
+
+
+create table EVENT (
+    ID   integer not null,
+    NAME text    not null,
+
+    primary key (ID),
+    unique (NAME)
+);
+
+
+create table CONCENTRIC_STREET (
+    EVENT integer not null,
+    ID    text    not null,
+    NAME  text    not null,
+
+    primary key (EVENT, ID)
+);
+
+
+create table INCIDENT_STATE (
+    ID text not null,
+
+    primary key (ID)
+);
+
+insert into INCIDENT_STATE (ID) values ('new');
+insert into INCIDENT_STATE (ID) values ('on_hold');
+insert into INCIDENT_STATE (ID) values ('dispatched');
+insert into INCIDENT_STATE (ID) values ('on_scene');
+insert into INCIDENT_STATE (ID) values ('closed');
+
+
+create table INCIDENT_TYPE (
+    ID     integer not null,
+    NAME   text    not null,
+    HIDDEN numeric not null,
+
+    primary key (ID),
+    unique (NAME)
+);
+
+insert into INCIDENT_TYPE (NAME, HIDDEN) values ('Admin', 0);
+insert into INCIDENT_TYPE (NAME, HIDDEN) values ('Junk', 0);
+
+
+create table REPORT_ENTRY (
+    ID        integer not null,
+    AUTHOR    text    not null,
+    TEXT      text    not null,
+    CREATED   real    not null,
+    GENERATED numeric not null,
+    STRICKEN  numeric not null,
+
+    ATTACHED_FILE text,
+    -- FIXME: AUTHOR is an external non-primary key.
+    -- Primary key is DMS Person ID.
+
+    primary key (ID)
+);
+
+
+create table INCIDENT (
+    EVENT    integer not null,
+    NUMBER   integer not null,
+    CREATED  real    not null,
+    PRIORITY integer not null,
+    STATE    integer not null,
+    SUMMARY  text,
+
+    LOCATION_NAME          text,
+    LOCATION_CONCENTRIC    text,
+    LOCATION_RADIAL_HOUR   integer,
+    LOCATION_RADIAL_MINUTE integer,
+    LOCATION_DESCRIPTION   text,
+
+    foreign key (EVENT) references EVENT(ID),
+    foreign key (STATE) references INCIDENT_STATE(ID),
+
+    foreign key (EVENT, LOCATION_CONCENTRIC)
+    references CONCENTRIC_STREET(EVENT, ID),
+
+    primary key (EVENT, NUMBER)
+);
+
+
+create table INCIDENT__RANGER (
+    EVENT           integer not null,
+    INCIDENT_NUMBER integer not null,
+    RANGER_HANDLE   text    not null,
+
+    foreign key (EVENT) references EVENT(ID),
+    foreign key (EVENT, INCIDENT_NUMBER) references INCIDENT(EVENT, NUMBER),
+
+    -- FIXME: RANGER_HANDLE is an external non-primary key.
+    -- Primary key is DMS Person ID.
+
+    primary key (EVENT, INCIDENT_NUMBER, RANGER_HANDLE)
+);
+
+
+create table INCIDENT__INCIDENT_TYPE (
+    EVENT           integer not null,
+    INCIDENT_NUMBER integer not null,
+    INCIDENT_TYPE   integer not null,
+
+    foreign key (EVENT) references EVENT(ID),
+    foreign key (EVENT, INCIDENT_NUMBER) references INCIDENT(EVENT, NUMBER),
+    foreign key (INCIDENT_TYPE) references INCIDENT_TYPE(ID),
+
+    primary key (EVENT, INCIDENT_NUMBER, INCIDENT_TYPE)
+);
+
+
+create table INCIDENT__REPORT_ENTRY (
+    EVENT           integer not null,
+    INCIDENT_NUMBER integer not null,
+    REPORT_ENTRY    integer not null,
+
+    foreign key (EVENT) references EVENT(ID),
+    foreign key (EVENT, INCIDENT_NUMBER) references INCIDENT(EVENT, NUMBER),
+    foreign key (REPORT_ENTRY) references REPORT_ENTRY(ID),
+
+    primary key (EVENT, INCIDENT_NUMBER, REPORT_ENTRY)
+);
+
+
+create table ACCESS_MODE (
+    ID text not null,
+
+    primary key (ID)
+);
+
+insert into ACCESS_MODE (ID) values ('read'  );
+insert into ACCESS_MODE (ID) values ('write' );
+insert into ACCESS_MODE (ID) values ('report');
+
+create table ACCESS_VALIDITY (
+    ID text not null,
+
+    primary key (ID)
+);
+
+insert into ACCESS_VALIDITY (ID) values ('always');
+insert into ACCESS_VALIDITY (ID) values ('onsite');
+
+create table EVENT_ACCESS (
+    EVENT      integer not null,
+    EXPRESSION text    not null,
+    MODE       text    not null,
+    VALIDITY   text    not null default ('always'),
+
+    foreign key (EVENT) references EVENT(ID),
+    foreign key (MODE) references ACCESS_MODE(ID),
+    foreign key (VALIDITY) references ACCESS_VALIDITY(ID),
+
+    primary key (EVENT, EXPRESSION)
+);
+
+
+create table FIELD_REPORT (
+    EVENT           integer not null,
+    NUMBER          integer not null,
+    CREATED         real    not null,
+
+    SUMMARY         text,
+    INCIDENT_NUMBER integer,
+
+    foreign key (EVENT) references EVENT(ID),
+    foreign key (EVENT, INCIDENT_NUMBER) references INCIDENT(EVENT, NUMBER),
+
+    primary key (EVENT, NUMBER)
+);
+
+
+create table FIELD_REPORT__REPORT_ENTRY (
+    EVENT                  integer not null,
+    FIELD_REPORT_NUMBER    integer not null,
+    REPORT_ENTRY           integer not null,
+
+    foreign key (EVENT) references EVENT(ID),
+    foreign key (EVENT, FIELD_REPORT_NUMBER)
+        references FIELD_REPORT(EVENT, NUMBER),
+    foreign key (REPORT_ENTRY) references REPORT_ENTRY(ID),
+
+    primary key (EVENT, FIELD_REPORT_NUMBER, REPORT_ENTRY)
+);

--- a/src/ims/store/sqlite/test/test_store_core.py
+++ b/src/ims/store/sqlite/test/test_store_core.py
@@ -76,7 +76,7 @@ class DataStoreCoreTests(AsynchronousTestCase):
             schemaInfo.lower(),
             dedent(
                 """
-                Version: 6
+                Version: 7
                 ACCESS_MODE:
                   0: ID(text) not null *1
                 ACCESS_VALIDITY:
@@ -140,6 +140,7 @@ class DataStoreCoreTests(AsynchronousTestCase):
                   3: CREATED(real) not null
                   4: GENERATED(numeric) not null
                   5: STRICKEN(numeric) not null
+                  6: ATTACHED_FILE(text)
                 SCHEMA_INFO:
                   0: VERSION(integer) not null
                 """[1:]


### PR DESCRIPTION
There was a lingering problem with FIELD_REPORT__REPORT_ENTRY, in that one of its constraints referenced the now-renamed INCIDENT_REPORT table (now FIELD_REPORT). Suddenly I was starting to see problems with that constraint locally, which is how I noticed it never got updated in MariaDB. This migration removes possible old forms of the constraint, and adds a new consistent one instead.

Also, this adds the new ATTACHED_FILE column, which is what I was really working on. The foreign key bug came about all of a sudden on my computer, which was really weird.