### PR TITLE
highlight active page in navbar

### DIFF
--- a/src/ims/element/static/ims.js
+++ b/src/ims/element/static/ims.js
@@ -373,6 +373,12 @@ async function loadBody() {
         const eventFieldReports = document.getElementById("active-event-field-reports");
         eventFieldReports.setAttribute("href", urlReplace(url_viewFieldReports));
         eventFieldReports.classList.remove("hidden");
+
+        if (window.location.pathname.startsWith(urlReplace(url_viewIncidents))) {
+            eventIncidents.classList.add("active");
+        } else if (window.location.pathname.startsWith(urlReplace(url_viewFieldReports))) {
+            eventFieldReports.classList.add("active");
+        }
     }
 }
 


### PR DESCRIPTION
this lights up the "incidents" link when you're on the incidents or incident page, and similar for field report(s)