### PR TITLE
permit admins to view street names

### DIFF
--- a/src/ims/application/_api.py
+++ b/src/ims/application/_api.py
@@ -1351,7 +1351,9 @@ class APIApplication:
             for event in await store.events():
                 try:
                     await self.config.authProvider.authorizeRequest(
-                        request, event.id, Authorization.readIncidents
+                        request,
+                        event.id,
+                        Authorization.readIncidents | Authorization.imsAdmin,
                     )
                 except NotAuthorizedError:
                     pass


### PR DESCRIPTION
prior to this, the admin streets page wouldn't show you streets for an event if you didn't have readIncidents on that event. It's an admin page, and an admin should be able to see the street names in order to adminster them.