### PR TITLE
remove "autofocus" from report entry add field

### DIFF
--- a/src/ims/element/incident/incident_template/template.xhtml
+++ b/src/ims/element/incident/incident_template/template.xhtml
@@ -250,7 +250,6 @@
                   class="form-control no-print"
                   rows="3"
                   placeholder="Press &quot;a&quot; to add report text"
-                  autofocus=""
                   onchange="reportEntryEdited()"
           />
           <div class="d-flex justify-content-between">

--- a/src/ims/element/incident/report_template/template.xhtml
+++ b/src/ims/element/incident/report_template/template.xhtml
@@ -146,7 +146,6 @@
                     class="form-control no-print input-sm"
                     rows="12"
                     placeholder="Press &quot;a&quot; to add report text"
-                    autofocus=""
                     onchange="reportEntryEdited()"
             />
             <button


### PR DESCRIPTION
it's now super obvious that you can jump to this field by pressing "a", so there's no no need for the autofocus