### PR TITLE
allow creating event streets from the admin streets page

### DIFF
--- a/src/ims/application/_api.py
+++ b/src/ims/application/_api.py
@@ -1376,6 +1376,8 @@ class APIApplication:
     ) -> KleinSynchronousRenderable:
         """
         Street list edit endpoint.
+
+        The API currently supports addition of streets, but not removal or modification.
         """
         await self.config.authProvider.authorizeRequest(
             request, None, Authorization.imsAdmin
@@ -1387,12 +1389,6 @@ class APIApplication:
             edits = objectFromJSONBytesIO(request.content)
         except JSONDecodeError as e:
             return invalidJSONResponse(request, e)
-
-        for eventID in edits.keys():
-            existing = await store.concentricStreets(eventID)
-
-            for _streetID, _streetName in existing.items():
-                raise NotAuthorizedError("Removal of streets is not allowed.")
 
         for eventID, streets in edits.items():
             existing = await store.concentricStreets(eventID)

--- a/src/ims/element/admin/streets/template.xhtml
+++ b/src/ims/element/admin/streets/template.xhtml
@@ -5,6 +5,11 @@
 
 <body>
 <div t:render="container">
+  <p>
+    <strong>IMPORTANT</strong>: this page/the API does not permit editing or removing streets once they've been added. Further edits must be
+    done via SQL against the IMS database. Get it right the first time!
+  </p>
+  <p>Each new street must be added with an identifying integer. That ID dictates the order that streets are shown on the Incident page.</p>
   <div class="row" id="event_streets_container">
 
     <div class="col-sm-12 event_streets">
@@ -15,6 +20,16 @@
             <li class="list-group-item">
             </li>
           </ul>
+          <div class="card-footer">
+            <label for="street_add">Add:</label>
+            <input
+                    id="street_add"
+                    class="form-control input-sm auto-width"
+                    type="text" inputmode="verbatim"
+                    placeholder="305:3:00 Public Plaza"
+                    onchange="addStreet(this)"
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/src/ims/element/static/admin_streets.js
+++ b/src/ims/element/static/admin_streets.js
@@ -71,17 +71,45 @@ function updateEventStreets(event) {
         entryContainer.append(entryItem);
     }
 }
-function addStreet(_sender) {
-    alert("Add unimplemented");
+async function addStreet(sender) {
+    const container = sender.closest(".event_streets");
+    const event = container.getElementsByClassName("event_name")[0].textContent;
+    const expression = sender.value.trim();
+    const splitInd = expression.indexOf(":");
+    if (splitInd === -1) {
+        alert("Expected a ':' in the expression");
+        return;
+    }
+    // e.g. "123: Abraham Ave" becomes "123" and "Abraham Ave"
+    const id = expression.substring(0, splitInd);
+    const name = expression.substring(splitInd + 1).trim();
+    const edits = {};
+    edits[event] = {};
+    edits[event][id] = name;
+    const { err } = await sendStreets(edits);
+    await loadStreets();
+    updateEventStreets(event);
+    if (err != null) {
+        controlHasError(sender);
+        return;
+    }
+    else {
+        controlHasSuccess(sender, 1000);
+    }
+    sender.value = "";
 }
 function removeStreet(_sender) {
-    alert("Remove unimplemented");
+    alert("Remove is unsupported for streets. Do this via SQL instead.");
 }
 async function sendStreets(edits) {
-    const { err } = await fetchJsonNoThrow(url_streets, edits);
+    const { err } = await fetchJsonNoThrow(url_streets, {
+        body: JSON.stringify(edits),
+    });
     if (err != null) {
         const message = `Failed to edit streets:\n${err}`;
         console.log(message);
         window.alert(message);
+        return { err: err };
     }
+    return { err: null };
 }

--- a/src/ims/element/typescript/admin_events.ts
+++ b/src/ims/element/typescript/admin_events.ts
@@ -38,6 +38,7 @@ interface Access {
 const allAccessModes = ["readers", "writers", "reporters"] as const;
 type AccessMode = typeof allAccessModes[number];
 type EventAccess = Partial<Record<AccessMode, Access[]>>;
+// key is event name
 type EventsAccess = Record<string, EventAccess|null>;
 
 let accessControlList: EventsAccess|null = null;


### PR DESCRIPTION
the API didn't allow creating new streets, but that seemed like a bug. It's more intentional that the API disallows deleting streets (probably due to foreign key worries), so I'm not allowing deletion from the UI either.

https://github.com/burningmantech/ranger-ims-server/issues/1643