### PR TITLE
clean up the dark/light mode code

### DIFF
--- a/src/ims/config/_urls.py
+++ b/src/ims/config/_urls.py
@@ -115,6 +115,8 @@ class URLs:
 
     imsJS: ClassVar[URL] = static.child("ims.js")
 
+    themeJS: ClassVar[URL] = static.child("theme.js")
+
     admin: ClassVar[URL] = app.child("admin").child("")
     adminJS: ClassVar[URL] = static.child("admin.js")
 

--- a/src/ims/element/admin/events/template.xhtml
+++ b/src/ims/element/admin/events/template.xhtml
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" t:render="root">
 
-<head t:render="head" imports="ims,adminEvents"/>
+<head t:render="head" imports="theme,ims,adminEvents"/>
 
 <body>
 <div t:render="container">
@@ -63,7 +63,6 @@
 
 <script>
     initAdminEventsPage();
-    applyTheme();
 </script>
 
 </html>

--- a/src/ims/element/admin/itypes/template.xhtml
+++ b/src/ims/element/admin/itypes/template.xhtml
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" t:render="root">
 
-<head t:render="head" imports="ims,adminIncidentTypes"/>
+<head t:render="head" imports="theme,ims,adminIncidentTypes"/>
 
 <body>
 <div t:render="container">
@@ -41,7 +41,6 @@
     var events = <json t:render="events_list"/>;
 
     initAdminTypesPage();
-    applyTheme();
 </script>
 
 </html>

--- a/src/ims/element/admin/root/template.xhtml
+++ b/src/ims/element/admin/root/template.xhtml
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" t:render="root">
 
-<head t:render="head" imports="ims,admin"/>
+<head t:render="head" imports="theme,ims,admin"/>
 
 <body>
 <div t:render="container">
@@ -27,7 +27,6 @@
 
 <script>
     initAdminPage();
-    applyTheme();
 </script>
 
 </html>

--- a/src/ims/element/admin/streets/template.xhtml
+++ b/src/ims/element/admin/streets/template.xhtml
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" t:render="root">
 
-<head t:render="head" imports="ims,adminStreets"/>
+<head t:render="head" imports="theme,ims,adminStreets"/>
 
 <body>
 <div t:render="container">
@@ -41,7 +41,6 @@
     var events = <json t:render="events_list"/>;
 
     initAdminStreetsPage();
-    applyTheme();
 </script>
 
 </html>

--- a/src/ims/element/incident/incident/template.xhtml
+++ b/src/ims/element/incident/incident/template.xhtml
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" t:render="root">
 
-<head t:render="head" imports="ims,viewIncident"/>
+<head t:render="head" imports="theme,ims,viewIncident"/>
 
 <body/>
 

--- a/src/ims/element/incident/incidents/template.xhtml
+++ b/src/ims/element/incident/incidents/template.xhtml
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" t:render="root">
-<head t:render="head" imports="dataTables,ims,viewIncidents"/>
+<head t:render="head" imports="theme,dataTables,ims,viewIncidents"/>
 
 <body/>
 

--- a/src/ims/element/incident/report/template.xhtml
+++ b/src/ims/element/incident/report/template.xhtml
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" t:render="root">
 
-<head t:render="head" imports="ims,viewFieldReport"/>
+<head t:render="head" imports="theme,ims,viewFieldReport"/>
 
 <body/>
 

--- a/src/ims/element/incident/reports/template.xhtml
+++ b/src/ims/element/incident/reports/template.xhtml
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" t:render="root">
-<head t:render="head" imports="dataTables,ims,viewFieldReports"/>
+<head t:render="head" imports="theme,dataTables,ims,viewFieldReports"/>
 
 <body/>
 

--- a/src/ims/element/login/template.xhtml
+++ b/src/ims/element/login/template.xhtml
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" t:render="root">
-<head t:render="head" imports="ims"/>
+<head t:render="head" imports="theme,ims"/>
 
 <body>
 <div t:render="container">
@@ -38,7 +38,6 @@
 </div>
 </body>
 <script>
-    applyTheme();
     document.getElementById("username_input")?.focus();
 </script>
 </html>

--- a/src/ims/element/root/template.xhtml
+++ b/src/ims/element/root/template.xhtml
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1">
-<head t:render="head" imports="ims"/>
+<head t:render="head" imports="theme,ims"/>
 
 <body t:render="container">
 
@@ -42,7 +42,6 @@
 </body>
 
 <script>
-  applyTheme();
   document.getElementById("login-button")?.focus();
 </script>
 </html>

--- a/src/ims/element/static/theme.js
+++ b/src/ims/element/static/theme.js
@@ -1,0 +1,89 @@
+"use strict";
+// See the file COPYRIGHT for copyright information.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// Set the theme immediately, before the rest of the page loads, so that there's
+// no flickering. We'll then come back later to applyTheme, which sets the navbar
+// dropdown icons.
+setTheme(getPreferredTheme());
+document.addEventListener("DOMContentLoaded", applyTheme);
+//
+// Apply the HTML theme, light or dark or default.
+//
+// Adapted from https://getbootstrap.com/docs/5.3/customize/color-modes/#javascript
+// Under Creative Commons Attribution 3.0 Unported License
+function getStoredTheme() {
+    return localStorage.getItem("theme");
+}
+function setStoredTheme(theme) {
+    localStorage.setItem("theme", theme);
+}
+function getPreferredTheme() {
+    const stored = getStoredTheme();
+    if (stored != null) {
+        return stored;
+    }
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+function setTheme(theme) {
+    if (theme === "auto") {
+        theme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    }
+    document.documentElement.setAttribute("data-bs-theme", theme);
+}
+function applyTheme() {
+    setTheme(getPreferredTheme());
+    function showActiveTheme(theme, focus = false) {
+        const themeSwitcher = document.querySelector("#bd-theme");
+        if (!themeSwitcher) {
+            return;
+        }
+        const themeSwitcherText = document.querySelector("#bd-theme-text");
+        const activeThemeIcon = document.querySelector(".theme-icon-active use");
+        const btnToActive = document.querySelector(`[data-bs-theme-value="${theme}"]`);
+        const svgOfActiveBtn = btnToActive.querySelector("svg use").href.baseVal;
+        document.querySelectorAll("[data-bs-theme-value]").forEach((element) => {
+            element.classList.remove("active");
+            element.setAttribute("aria-pressed", "false");
+        });
+        btnToActive.classList.add("active");
+        btnToActive.setAttribute("aria-pressed", "true");
+        if (svgOfActiveBtn) {
+            activeThemeIcon.href.baseVal = svgOfActiveBtn;
+        }
+        if (themeSwitcherText) {
+            const themeSwitcherLabel = `${themeSwitcherText.textContent} (${btnToActive.dataset["bsThemeValue"]})`;
+            themeSwitcher.setAttribute("aria-label", themeSwitcherLabel);
+        }
+        if (focus) {
+            themeSwitcher.focus();
+        }
+    }
+    window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => {
+        const storedTheme = getStoredTheme();
+        if (storedTheme !== "light" && storedTheme !== "dark") {
+            setTheme(getPreferredTheme());
+        }
+    });
+    showActiveTheme(getPreferredTheme());
+    document.querySelectorAll("[data-bs-theme-value]").forEach((toggle) => {
+        toggle.addEventListener("click", function (_e) {
+            const theme = toggle.getAttribute("data-bs-theme-value");
+            if (theme) {
+                setStoredTheme(theme);
+                setTheme(theme);
+                showActiveTheme(theme, true);
+            }
+        });
+    });
+}

--- a/src/ims/element/typescript/theme.ts
+++ b/src/ims/element/typescript/theme.ts
@@ -1,0 +1,101 @@
+// See the file COPYRIGHT for copyright information.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// Set the theme immediately, before the rest of the page loads, so that there's
+// no flickering. We'll then come back later to applyTheme, which sets the navbar
+// dropdown icons.
+setTheme(getPreferredTheme());
+document.addEventListener("DOMContentLoaded", applyTheme);
+
+//
+// Apply the HTML theme, light or dark or default.
+//
+// Adapted from https://getbootstrap.com/docs/5.3/customize/color-modes/#javascript
+// Under Creative Commons Attribution 3.0 Unported License
+
+function getStoredTheme(): string|null {
+    return localStorage.getItem("theme");
+}
+function setStoredTheme(theme: string): void {
+    localStorage.setItem("theme", theme);
+}
+function getPreferredTheme(): string {
+    const stored = getStoredTheme();
+    if (stored != null) {
+        return stored;
+    }
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+function setTheme(theme: string): void {
+    if (theme === "auto") {
+        theme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    }
+    document.documentElement.setAttribute("data-bs-theme", theme);
+}
+function applyTheme(): void {
+    setTheme(getPreferredTheme());
+
+    function showActiveTheme(theme: string, focus: boolean = false): void {
+        const themeSwitcher: HTMLButtonElement|null = document.querySelector("#bd-theme");
+
+        if (!themeSwitcher) {
+            return;
+        }
+
+        const themeSwitcherText: Element = document.querySelector("#bd-theme-text")!;
+        const activeThemeIcon = document.querySelector(".theme-icon-active use") as SVGUseElement;
+        const btnToActive: HTMLButtonElement = document.querySelector(`[data-bs-theme-value="${theme}"]`)!;
+        const svgOfActiveBtn: string = (btnToActive.querySelector("svg use") as SVGUseElement).href.baseVal;
+
+        document.querySelectorAll("[data-bs-theme-value]").forEach((element: Element): void => {
+            element.classList.remove("active");
+            element.setAttribute("aria-pressed", "false");
+        });
+
+        btnToActive.classList.add("active");
+        btnToActive.setAttribute("aria-pressed", "true");
+        if (svgOfActiveBtn) {
+            activeThemeIcon.href.baseVal = svgOfActiveBtn;
+        }
+        if (themeSwitcherText) {
+            const themeSwitcherLabel = `${themeSwitcherText.textContent} (${btnToActive.dataset["bsThemeValue"]})`;
+            themeSwitcher.setAttribute("aria-label", themeSwitcherLabel);
+        }
+
+        if (focus) {
+            themeSwitcher.focus();
+        }
+    }
+
+    window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", (): void => {
+        const storedTheme: string|null = getStoredTheme();
+        if (storedTheme !== "light" && storedTheme !== "dark") {
+            setTheme(getPreferredTheme());
+        }
+    });
+
+    showActiveTheme(getPreferredTheme());
+
+    document.querySelectorAll("[data-bs-theme-value]").forEach((toggle: Element): void => {
+        (toggle as HTMLElement).addEventListener("click", function(_e: MouseEvent): void {
+            const theme = toggle.getAttribute("data-bs-theme-value");
+            if (theme) {
+                setStoredTheme(theme);
+                setTheme(theme);
+                showActiveTheme(theme, true);
+            }
+        });
+    });
+}


### PR DESCRIPTION
This moves that code into a separate JS file (necessary for moving to JS modules) and it cleans up the invocation points for the theme code. i.e. we now call immediately on <src> load to apply any stored or preferred theme (to prevent flickering if done later), then we set up the navbar theme selector after DOMContentLoaded.

The relevance to modules is that modules are automatically deferred, so the aforementioned flicker would be unavoidable were the theme code to live in a module. Instead, this PR splits out that code into a separate (never-to-be-module) JS file.

https://github.com/burningmantech/ranger-ims-server/issues/1656