### PR TITLE
change primary key on INCIDENT__RANGER

### DIFF
--- a/src/ims/element/static/ims.js
+++ b/src/ims/element/static/ims.js
@@ -809,7 +809,7 @@ export function requestEventSourceLock() {
     // Secure contexts include HTTPS as well as non-HTTPS via localhost, so this is
     // really only when you try to connect directly to another host without TLS.
     // https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts
-    if (!window.isSecureContext && typeof setErrorMessage !== "undefined") {
+    if (!window.isSecureContext) {
         setErrorMessage("You're connected through an insecure browsing context. " +
             "Background SSE updates will not work!");
         return;

--- a/src/ims/element/typescript/ims.ts
+++ b/src/ims/element/typescript/ims.ts
@@ -1088,7 +1088,7 @@ export function requestEventSourceLock(): void  {
     // Secure contexts include HTTPS as well as non-HTTPS via localhost, so this is
     // really only when you try to connect directly to another host without TLS.
     // https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts
-    if (!window.isSecureContext && typeof setErrorMessage !== "undefined") {
+    if (!window.isSecureContext) {
         setErrorMessage("You're connected through an insecure browsing context. " +
             "Background SSE updates will not work!");
         return;

--- a/src/ims/store/mysql/_store.py
+++ b/src/ims/store/mysql/_store.py
@@ -100,7 +100,7 @@ class DataStore(DatabaseStore):
 
     _log: ClassVar[Logger] = Logger()
 
-    schemaVersion: ClassVar[int] = 11
+    schemaVersion: ClassVar[int] = 12
     schemaBasePath: ClassVar[Path] = Path(__file__).parent / "schema"
     sqlFileExtension: ClassVar[str] = "mysql"
 

--- a/src/ims/store/mysql/schema/12-from-11.mysql
+++ b/src/ims/store/mysql/schema/12-from-11.mysql
@@ -1,0 +1,20 @@
+/*
+  Change the problematic primary key for INCIDENT__RANGER,
+  which frequently causes transaction contention/rollback. Having
+  a VARCHAR as part of a primary key is ugly.
+
+  These rollbacks would probably never happen in prod, but
+  they were a nightmare in automated testing.
+
+  Related:
+  https://stackoverflow.com/questions/64789956/mariadb-innodb-deadlock-while-doing-many-inserts
+*/
+
+alter table `INCIDENT__RANGER`
+    add column `ID` int not null auto_increment first,
+    drop primary key,
+    add primary key(`ID`);
+
+/* Update schema version */
+
+update `SCHEMA_INFO` set `VERSION` = 12;

--- a/src/ims/store/mysql/schema/12.mysql
+++ b/src/ims/store/mysql/schema/12.mysql
@@ -1,0 +1,165 @@
+create table SCHEMA_INFO (
+    VERSION smallint not null
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+insert into SCHEMA_INFO (VERSION) values (12);
+
+
+create table EVENT (
+    ID   integer      not null auto_increment,
+    NAME varchar(128) not null,
+
+    primary key (ID),
+    unique key (NAME)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+create table CONCENTRIC_STREET (
+    EVENT integer      not null,
+    ID    varchar(16)  not null,
+    NAME  varchar(128) not null,
+
+    primary key (EVENT, ID)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+create table INCIDENT_TYPE (
+    ID     integer      not null auto_increment,
+    NAME   varchar(128) not null,
+    HIDDEN boolean      not null,
+
+    primary key (ID),
+    unique key (NAME)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+insert into INCIDENT_TYPE (NAME, HIDDEN) values ('Admin', 0);
+insert into INCIDENT_TYPE (NAME, HIDDEN) values ('Junk' , 0);
+
+
+create table REPORT_ENTRY (
+    ID        integer     not null auto_increment,
+    AUTHOR    varchar(64) not null,
+    TEXT      text        not null,
+    CREATED   double      not null,
+    GENERATED boolean     not null,
+    STRICKEN  boolean     not null,
+
+    ATTACHED_FILE varchar(128),
+
+    -- FIXME: AUTHOR is an external non-primary key.
+    -- Primary key is DMS Person ID.
+
+    primary key (ID)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+create table INCIDENT (
+    EVENT    integer  not null,
+    NUMBER   integer  not null,
+    CREATED  double   not null,
+    PRIORITY tinyint  not null,
+
+    STATE enum(
+        'new', 'on_hold', 'dispatched', 'on_scene', 'closed'
+    ) not null,
+
+    SUMMARY varchar(1024),
+
+    LOCATION_NAME          varchar(1024),
+    LOCATION_CONCENTRIC    varchar(64),
+    LOCATION_RADIAL_HOUR   tinyint,
+    LOCATION_RADIAL_MINUTE tinyint,
+    LOCATION_DESCRIPTION   varchar(1024),
+
+    foreign key (EVENT) references EVENT(ID),
+
+    foreign key (EVENT, LOCATION_CONCENTRIC)
+    references CONCENTRIC_STREET(EVENT, ID),
+
+    primary key (EVENT, NUMBER)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+create table INCIDENT__RANGER (
+    ID              integer     not null auto_increment,
+    EVENT           integer     not null,
+    INCIDENT_NUMBER integer     not null,
+    RANGER_HANDLE   varchar(64) not null,
+
+    foreign key (EVENT) references EVENT(ID),
+    foreign key (EVENT, INCIDENT_NUMBER) references INCIDENT(EVENT, NUMBER),
+
+    -- FIXME: RANGER_HANDLE is an external non-primary key.
+    -- Primary key is DMS Person ID.
+
+    primary key (ID)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+create table INCIDENT__INCIDENT_TYPE (
+    EVENT           integer not null,
+    INCIDENT_NUMBER integer not null,
+    INCIDENT_TYPE   integer not null,
+
+    foreign key (EVENT) references EVENT(ID),
+    foreign key (EVENT, INCIDENT_NUMBER) references INCIDENT(EVENT, NUMBER),
+    foreign key (INCIDENT_TYPE) references INCIDENT_TYPE(ID),
+
+    primary key (EVENT, INCIDENT_NUMBER, INCIDENT_TYPE)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+create table INCIDENT__REPORT_ENTRY (
+    EVENT           integer not null,
+    INCIDENT_NUMBER integer not null,
+    REPORT_ENTRY    integer not null,
+
+    foreign key (EVENT) references EVENT(ID),
+    foreign key (EVENT, INCIDENT_NUMBER) references INCIDENT(EVENT, NUMBER),
+    foreign key (REPORT_ENTRY) references REPORT_ENTRY(ID),
+
+    primary key (EVENT, INCIDENT_NUMBER, REPORT_ENTRY)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+create table EVENT_ACCESS (
+    ID         integer      not null auto_increment,
+    EVENT      integer      not null,
+    EXPRESSION varchar(128) not null,
+
+    MODE     enum ('read', 'write', 'report') not null,
+    VALIDITY enum ('always', 'onsite') not null default 'always',
+
+    foreign key (EVENT) references EVENT(ID),
+
+    primary key (ID)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+create table FIELD_REPORT (
+    EVENT   integer  not null,
+    NUMBER  integer  not null,
+    CREATED double   not null,
+
+    SUMMARY         varchar(1024),
+    INCIDENT_NUMBER integer,
+
+    foreign key (EVENT) references EVENT(ID),
+    foreign key (EVENT, INCIDENT_NUMBER) references INCIDENT(EVENT, NUMBER),
+
+    primary key (EVENT, NUMBER)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+create table FIELD_REPORT__REPORT_ENTRY (
+    EVENT                  integer not null,
+    FIELD_REPORT_NUMBER    integer not null,
+    REPORT_ENTRY           integer not null,
+
+    foreign key (EVENT) references EVENT(ID),
+    foreign key (EVENT, FIELD_REPORT_NUMBER)
+        references FIELD_REPORT(EVENT, NUMBER),
+    foreign key (REPORT_ENTRY) references REPORT_ENTRY(ID),
+
+    primary key (EVENT, FIELD_REPORT_NUMBER, REPORT_ENTRY)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/ims/store/mysql/test/test_store_core.py
+++ b/src/ims/store/mysql/test/test_store_core.py
@@ -144,7 +144,7 @@ class DataStoreCoreTests(AsynchronousTestCase):
         self.assertEqual(
             dedent(
                 """
-                Version: 11
+                Version: 12
                 CONCENTRIC_STREET:
                   1: EVENT(int) not null
                   2: ID(varchar(16)) not null
@@ -189,9 +189,10 @@ class DataStoreCoreTests(AsynchronousTestCase):
                   2: INCIDENT_NUMBER(int) not null
                   3: INCIDENT_TYPE(int) not null
                 INCIDENT__RANGER:
-                  1: EVENT(int) not null
-                  2: INCIDENT_NUMBER(int) not null
-                  3: RANGER_HANDLE(varchar(64)) not null
+                  1: ID(int) not null
+                  2: EVENT(int) not null
+                  3: INCIDENT_NUMBER(int) not null
+                  4: RANGER_HANDLE(varchar(64)) not null
                 INCIDENT__REPORT_ENTRY:
                   1: EVENT(int) not null
                   2: INCIDENT_NUMBER(int) not null


### PR DESCRIPTION
Primary keys involving VARCHAR columns seem prone to causing transaction deadlocks. Changing those to simple integer IDs makes the deadlocks go away. I previously did this for EVENT_ACCESS and that successfully made the deadlocks in that table go away.

There's an unrelated JS tweak in this PR too, removing an unnecessary check.

https://github.com/burningmantech/ranger-ims-server/issues/1662