### PR TITLE
add an index on INCIDENT__RANGER

### DIFF
--- a/src/ims/store/mysql/_store.py
+++ b/src/ims/store/mysql/_store.py
@@ -100,7 +100,7 @@ class DataStore(DatabaseStore):
 
     _log: ClassVar[Logger] = Logger()
 
-    schemaVersion: ClassVar[int] = 12
+    schemaVersion: ClassVar[int] = 13
     schemaBasePath: ClassVar[Path] = Path(__file__).parent / "schema"
     sqlFileExtension: ClassVar[str] = "mysql"
 

--- a/src/ims/store/mysql/schema/13-from-12.mysql
+++ b/src/ims/store/mysql/schema/13-from-12.mysql
@@ -1,0 +1,15 @@
+/*
+  Add an index on INCIDENT__RANGER
+
+  I was a bit brash in 12-from-11. In removing EVENT and INCIDENT_NUMBER
+  from the PK, I made our lookups into this table significantly slower.
+  We can have the best of both worlds, by continuing to not have a VARCHAR
+  as part of the PK, but also by having a (non-unique) index on the table.
+*/
+
+create index INCIDENT__RANGER_EVENT_INCIDENT_NUMBER_index
+    on `INCIDENT__RANGER` (EVENT, INCIDENT_NUMBER);
+
+/* Update schema version */
+
+update `SCHEMA_INFO` set `VERSION` = 13;

--- a/src/ims/store/mysql/schema/13.mysql
+++ b/src/ims/store/mysql/schema/13.mysql
@@ -1,0 +1,168 @@
+create table SCHEMA_INFO (
+    VERSION smallint not null
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+insert into SCHEMA_INFO (VERSION) values (13);
+
+
+create table EVENT (
+    ID   integer      not null auto_increment,
+    NAME varchar(128) not null,
+
+    primary key (ID),
+    unique key (NAME)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+create table CONCENTRIC_STREET (
+    EVENT integer      not null,
+    ID    varchar(16)  not null,
+    NAME  varchar(128) not null,
+
+    primary key (EVENT, ID)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+create table INCIDENT_TYPE (
+    ID     integer      not null auto_increment,
+    NAME   varchar(128) not null,
+    HIDDEN boolean      not null,
+
+    primary key (ID),
+    unique key (NAME)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+insert into INCIDENT_TYPE (NAME, HIDDEN) values ('Admin', 0);
+insert into INCIDENT_TYPE (NAME, HIDDEN) values ('Junk' , 0);
+
+
+create table REPORT_ENTRY (
+    ID        integer     not null auto_increment,
+    AUTHOR    varchar(64) not null,
+    TEXT      text        not null,
+    CREATED   double      not null,
+    GENERATED boolean     not null,
+    STRICKEN  boolean     not null,
+
+    ATTACHED_FILE varchar(128),
+
+    -- FIXME: AUTHOR is an external non-primary key.
+    -- Primary key is DMS Person ID.
+
+    primary key (ID)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+create table INCIDENT (
+    EVENT    integer  not null,
+    NUMBER   integer  not null,
+    CREATED  double   not null,
+    PRIORITY tinyint  not null,
+
+    STATE enum(
+        'new', 'on_hold', 'dispatched', 'on_scene', 'closed'
+    ) not null,
+
+    SUMMARY varchar(1024),
+
+    LOCATION_NAME          varchar(1024),
+    LOCATION_CONCENTRIC    varchar(64),
+    LOCATION_RADIAL_HOUR   tinyint,
+    LOCATION_RADIAL_MINUTE tinyint,
+    LOCATION_DESCRIPTION   varchar(1024),
+
+    foreign key (EVENT) references EVENT(ID),
+
+    foreign key (EVENT, LOCATION_CONCENTRIC)
+    references CONCENTRIC_STREET(EVENT, ID),
+
+    primary key (EVENT, NUMBER)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+create table INCIDENT__RANGER (
+    ID              integer     not null auto_increment,
+    EVENT           integer     not null,
+    INCIDENT_NUMBER integer     not null,
+    RANGER_HANDLE   varchar(64) not null,
+
+    foreign key (EVENT) references EVENT(ID),
+    foreign key (EVENT, INCIDENT_NUMBER) references INCIDENT(EVENT, NUMBER),
+
+    -- FIXME: RANGER_HANDLE is an external non-primary key.
+    -- Primary key is DMS Person ID.
+
+    primary key (ID)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+create index `INCIDENT__RANGER_EVENT_INCIDENT_NUMBER_index`
+    on `INCIDENT__RANGER` (EVENT, INCIDENT_NUMBER);
+
+
+create table INCIDENT__INCIDENT_TYPE (
+    EVENT           integer not null,
+    INCIDENT_NUMBER integer not null,
+    INCIDENT_TYPE   integer not null,
+
+    foreign key (EVENT) references EVENT(ID),
+    foreign key (EVENT, INCIDENT_NUMBER) references INCIDENT(EVENT, NUMBER),
+    foreign key (INCIDENT_TYPE) references INCIDENT_TYPE(ID),
+
+    primary key (EVENT, INCIDENT_NUMBER, INCIDENT_TYPE)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+create table INCIDENT__REPORT_ENTRY (
+    EVENT           integer not null,
+    INCIDENT_NUMBER integer not null,
+    REPORT_ENTRY    integer not null,
+
+    foreign key (EVENT) references EVENT(ID),
+    foreign key (EVENT, INCIDENT_NUMBER) references INCIDENT(EVENT, NUMBER),
+    foreign key (REPORT_ENTRY) references REPORT_ENTRY(ID),
+
+    primary key (EVENT, INCIDENT_NUMBER, REPORT_ENTRY)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+create table EVENT_ACCESS (
+    ID         integer      not null auto_increment,
+    EVENT      integer      not null,
+    EXPRESSION varchar(128) not null,
+
+    MODE     enum ('read', 'write', 'report') not null,
+    VALIDITY enum ('always', 'onsite') not null default 'always',
+
+    foreign key (EVENT) references EVENT(ID),
+
+    primary key (ID)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+create table FIELD_REPORT (
+    EVENT   integer  not null,
+    NUMBER  integer  not null,
+    CREATED double   not null,
+
+    SUMMARY         varchar(1024),
+    INCIDENT_NUMBER integer,
+
+    foreign key (EVENT) references EVENT(ID),
+    foreign key (EVENT, INCIDENT_NUMBER) references INCIDENT(EVENT, NUMBER),
+
+    primary key (EVENT, NUMBER)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+create table FIELD_REPORT__REPORT_ENTRY (
+    EVENT                  integer not null,
+    FIELD_REPORT_NUMBER    integer not null,
+    REPORT_ENTRY           integer not null,
+
+    foreign key (EVENT) references EVENT(ID),
+    foreign key (EVENT, FIELD_REPORT_NUMBER)
+        references FIELD_REPORT(EVENT, NUMBER),
+    foreign key (REPORT_ENTRY) references REPORT_ENTRY(ID),
+
+    primary key (EVENT, FIELD_REPORT_NUMBER, REPORT_ENTRY)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/ims/store/mysql/test/test_store_core.py
+++ b/src/ims/store/mysql/test/test_store_core.py
@@ -144,7 +144,7 @@ class DataStoreCoreTests(AsynchronousTestCase):
         self.assertEqual(
             dedent(
                 """
-                Version: 12
+                Version: 13
                 CONCENTRIC_STREET:
                   1: EVENT(int) not null
                   2: ID(varchar(16)) not null


### PR DESCRIPTION
I previously changed the PK on this table, and that led to very long lookups on this table (e.g. staging incidents page for 2023 takes around 11 seconds to load all incidents). An index fixes this, without the baggage of a VARCHAR in the PK, which is what we had before schema version 12.