### PR TITLE
add a fetch auth API

### DIFF
--- a/src/ims/auth/_provider.py
+++ b/src/ims/auth/_provider.py
@@ -332,6 +332,11 @@ class AuthProvider:
             authorization = request.getHeader(HeaderName.authorization.value)
             user = self._userFromBearerAuthorization(authorization)
 
+            if user is not None:
+                sess = request.getSession()
+                if sess:
+                    sess.user = user
+
             if user is None:
                 session = request.getSession()
                 user = getattr(session, "user", None)


### PR DESCRIPTION
this endpoint says whether a session is authenticated and, if so, it gives details about that session and the user's permissions

this will allow me to cut all remaining reliance on authenticated server-side rendering, allowing us to move over to bearer tokens fully, away from TWISTED_SESSION

https://github.com/burningmantech/ranger-ims-server/issues/1671 https://github.com/burningmantech/ranger-ims-server/issues/1363#issuecomment-2466195574