### PR TITLE
stop using authenticated server-side rendering

### DIFF
--- a/src/ims/application/_web.py
+++ b/src/ims/application/_web.py
@@ -26,7 +26,6 @@ from klein import KleinRenderable
 from klein._app import KleinSynchronousRenderable
 from twisted.web.iweb import IRequest
 
-from ims.auth import Authorization, NotAuthorizedError
 from ims.config import Configuration, URLs
 from ims.element.admin.events import AdminEventsPage
 from ims.element.admin.itypes import AdminIncidentTypesPage
@@ -38,9 +37,8 @@ from ims.element.incident.report import FieldReportPage
 from ims.element.incident.reports import FieldReportsPage
 from ims.element.root import RootPage
 from ims.model import Event
-from ims.store import NoSuchFieldReportError
 
-from ._klein import Router, notFoundResponse, redirect
+from ._klein import Router, redirect
 
 
 __all__ = ("WebApplication",)
@@ -82,30 +80,13 @@ class WebApplication:
 
         This redirects to the event's incidents page.
         """
-        try:
-            await self.config.authProvider.authorizeRequest(
-                request, event_id, Authorization.readIncidents
-            )
-            url = URLs.viewIncidentsRelative
-        except NotAuthorizedError:
-            await self.config.authProvider.authorizeRequest(
-                request, event_id, Authorization.writeFieldReports
-            )
-            url = URLs.viewFieldReportsRelative
-
-        return redirect(request, url)
+        return redirect(request, URLs.viewIncidentsRelative)
 
     @router.route(_unprefix(URLs.admin), methods=("HEAD", "GET"))
     async def adminPage(self, request: IRequest) -> KleinSynchronousRenderable:
         """
         Endpoint for admin page.
         """
-        # FIXME: Not strictly required because the underlying data is
-        # protected.
-        # But the error you get is stupid, so let's avoid that for now.
-        await self.config.authProvider.authorizeRequest(
-            request, None, Authorization.imsAdmin
-        )
         return AdminRootPage(config=self.config)
 
     @router.route(_unprefix(URLs.adminEvents), methods=("HEAD", "GET"))
@@ -113,12 +94,6 @@ class WebApplication:
         """
         Endpoint for access control page.
         """
-        # FIXME: Not strictly required because the underlying data is
-        # protected.
-        # But the error you get is stupid, so let's avoid that for now.
-        await self.config.authProvider.authorizeRequest(
-            request, None, Authorization.imsAdmin
-        )
         return AdminEventsPage(config=self.config)
 
     @router.route(_unprefix(URLs.adminIncidentTypes), methods=("HEAD", "GET"))
@@ -128,12 +103,6 @@ class WebApplication:
         """
         Endpoint for incident types admin page.
         """
-        # FIXME: Not strictly required because the underlying data is
-        # protected.
-        # But the error you get is stupid, so let's avoid that for now.
-        await self.config.authProvider.authorizeRequest(
-            request, None, Authorization.imsAdmin
-        )
         return AdminIncidentTypesPage(config=self.config)
 
     @router.route(_unprefix(URLs.adminStreets), methods=("HEAD", "GET"))
@@ -141,12 +110,6 @@ class WebApplication:
         """
         Endpoint for streets admin page.
         """
-        # FIXME: Not strictly required because the underlying data is
-        # protected.
-        # But the error you get is stupid, so let's avoid that for now.
-        await self.config.authProvider.authorizeRequest(
-            request, None, Authorization.imsAdmin
-        )
         return AdminStreetsPage(config=self.config)
 
     @router.route(_unprefix(URLs.viewIncidents), methods=("HEAD", "GET"))
@@ -156,12 +119,6 @@ class WebApplication:
         """
         Endpoint for the incidents page.
         """
-        # FIXME: Not strictly required because the underlying data is
-        # protected.
-        # But the error you get is stupid, so let's avoid that for now.
-        await self.config.authProvider.authorizeRequest(
-            request, event_id, Authorization.readIncidents
-        )
         event = Event(id=event_id)
         return IncidentsPage(config=self.config, event=event)
 
@@ -172,21 +129,8 @@ class WebApplication:
         """
         Endpoint for the incident page.
         """
-        numberValue: int | None
-        if number == "new":
-            authz = Authorization.writeIncidents
-            numberValue = None
-        else:
-            authz = Authorization.readIncidents
-            try:
-                numberValue = int(number)
-            except ValueError:
-                return notFoundResponse(request)
-
-        await self.config.authProvider.authorizeRequest(request, event_id, authz)
-
         event = Event(id=event_id)
-        return IncidentPage(config=self.config, event=event, number=numberValue)
+        return IncidentPage(config=self.config, event=event)
 
     @router.route(_unprefix(URLs.viewFieldReports), methods=("HEAD", "GET"))
     async def viewFieldReportsPage(
@@ -195,14 +139,6 @@ class WebApplication:
         """
         Endpoint for the field reports page.
         """
-        try:
-            await self.config.authProvider.authorizeRequest(
-                request, event_id, Authorization.readIncidents
-            )
-        except NotAuthorizedError:
-            await self.config.authProvider.authorizeRequest(
-                request, event_id, Authorization.writeFieldReports
-            )
         event = Event(id=event_id)
         return FieldReportsPage(config=self.config, event=event)
 
@@ -213,34 +149,6 @@ class WebApplication:
         """
         Endpoint for the field report page.
         """
-        fieldReportNumber: int | None
         config = self.config
-        if number == "new":
-            await config.authProvider.authorizeRequest(
-                request, event_id, Authorization.writeFieldReports
-            )
-            fieldReportNumber = None
-            del number
-        else:
-            try:
-                fieldReportNumber = int(number)
-            except ValueError:
-                return notFoundResponse(request)
-            del number
-
-            try:
-                fieldReport = await config.store.fieldReportWithNumber(
-                    event_id, fieldReportNumber
-                )
-            except NoSuchFieldReportError:
-                await config.authProvider.authorizeRequest(
-                    request, event_id, Authorization.readIncidents
-                )
-                return notFoundResponse(request)
-
-            await config.authProvider.authorizeRequestForFieldReport(
-                request, fieldReport
-            )
-
         event = Event(id=event_id)
-        return FieldReportPage(config=config, event=event, number=fieldReportNumber)
+        return FieldReportPage(config=config, event=event)

--- a/src/ims/config/_urls.py
+++ b/src/ims/config/_urls.py
@@ -80,6 +80,7 @@ class URLs:
 
     authApp: ClassVar[URL] = prefix.child("auth").child("")
     login: ClassVar[URL] = authApp.child("login")
+    loginJS: ClassVar[URL] = static.child("login.js")
     logout: ClassVar[URL] = authApp.child("logout")
 
     # External application
@@ -112,14 +113,14 @@ class URLs:
     # Web application
 
     app: ClassVar[URL] = prefix.child("app").child("")
+    rootJS: ClassVar[URL] = static.child("root.js")
 
     imsJS: ClassVar[URL] = static.child("ims.js")
-
-    basicJS: ClassVar[URL] = static.child("basic.js")
 
     themeJS: ClassVar[URL] = static.child("theme.js")
 
     admin: ClassVar[URL] = app.child("admin").child("")
+    adminRootJS: ClassVar[URL] = static.child("admin_root.js")
 
     adminEvents: ClassVar[URL] = admin.child("events")
     adminEventsJS: ClassVar[URL] = static.child("admin_events.js")

--- a/src/ims/element/_element.py
+++ b/src/ims/element/_element.py
@@ -30,7 +30,7 @@ from twisted.web.template import Element as _Element
 from twisted.web.template import Tag, XMLFile, renderer
 
 from ims.config import Configuration
-from ims.ext.json_ext import jsonFalse, jsonTextFromObject, jsonTrue
+from ims.ext.json_ext import jsonTextFromObject
 
 
 __all__ = ()
@@ -87,64 +87,6 @@ class Element(BaseElement):
     # Logged in state
     ##
 
-    def isAuthenticated(self, request: IRequest) -> bool:
-        return getattr(request, "user", None) is not None
-
-    def isAdmin(self, request: IRequest) -> bool:
-        user = getattr(request, "user", None)
-
-        if user is not None:
-            for shortName in user.shortNames:
-                if shortName in self.config.imsAdmins:
-                    return True
-
-        return False
-
-    @renderer
-    def if_logged_in(self, request: IRequest, tag: Tag) -> KleinRenderable:
-        """
-        Render conditionally if the user is logged in.
-        """
-        if self.isAuthenticated(request):
-            return tag
-        return ""
-
-    @renderer
-    def if_not_logged_in(self, request: IRequest, tag: Tag) -> KleinRenderable:
-        """
-        Render conditionally if the user is not logged in.
-        """
-        if self.isAuthenticated(request):
-            return ""
-        return tag
-
-    @renderer
-    def if_admin(self, request: IRequest, tag: Tag) -> KleinRenderable:
-        """
-        Render conditionally if the user is an admin.
-        """
-        if self.isAdmin(request):
-            return tag
-        return ""
-
-    @renderer
-    def logged_in_user(self, request: IRequest, tag: Tag) -> KleinRenderable:
-        """
-        Embed the logged in user into an element content.
-        """
-        user = getattr(request, "user", None)
-        if user is None:
-            username = "(anonymous user)"
-        else:
-            try:
-                username = user.shortNames[0]
-            except IndexError:
-                username = "* NO USER NAME *"
-
-        if tag.tagName == "text":
-            return username
-        return tag(username)
-
     @renderer
     def deployment_warning(self, request: IRequest, tag: Tag) -> KleinRenderable:
         deployment = self.config.deployment.lower()
@@ -197,14 +139,3 @@ class Element(BaseElement):
 
         tag.attributes[attributeName] = text
         return tag
-
-    @renderer
-    def file_attachments_allowed(self, request: IRequest, tag: Tag) -> KleinRenderable:
-        """
-        Identifies if file attachment uploads are allowed by the server.
-        """
-        return (
-            jsonFalse
-            if self.config.attachmentsStoreType.lower() == "none"
-            else jsonTrue
-        )

--- a/src/ims/element/admin/itypes/template.xhtml
+++ b/src/ims/element/admin/itypes/template.xhtml
@@ -27,6 +27,7 @@
           <input
                   class="form-control input-sm auto-width"
                   type="text" inputmode="verbatim"
+                  disabled=""
                   placeholder="Chooch"
                   onchange="createIncidentType(this)"
           />

--- a/src/ims/element/admin/root/template.xhtml
+++ b/src/ims/element/admin/root/template.xhtml
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" t:render="root">
 
-<head t:render="head" imports="theme" module="basic"/>
+<head t:render="head" imports="theme" module="adminRoot"/>
 
 <body>
 <div t:render="container">

--- a/src/ims/element/incident/incident/_incident.py
+++ b/src/ims/element/incident/incident/_incident.py
@@ -19,12 +19,7 @@ Incident page.
 """
 
 from attrs import mutable
-from klein import KleinRenderable
-from twisted.web.iweb import IRequest
-from twisted.web.template import Tag, renderer
 
-from ims.auth import Authorization
-from ims.ext.json_ext import jsonFalse, jsonTrue
 from ims.model import Event
 
 from ...page import Page
@@ -42,16 +37,3 @@ class IncidentPage(Page):
     name: str = "Incident Details"
     hideH1: bool = True
     event: Event
-    number: int | None
-
-    @renderer
-    def editing_allowed(self, request: IRequest, tag: Tag) -> KleinRenderable:
-        """
-        JSON boolean, true if editing is allowed.
-        """
-        if (
-            request.authorizations  # type: ignore[attr-defined]
-            & Authorization.writeIncidents
-        ):
-            return jsonTrue
-        return jsonFalse

--- a/src/ims/element/incident/incident/template.xhtml
+++ b/src/ims/element/incident/incident/template.xhtml
@@ -3,12 +3,6 @@
 
 <head t:render="head" imports="theme" module="viewIncident"/>
 
-<script>
-    <!-- FIXME: figure out how to move this to / include from incident.js -->
-    const editingAllowed            = <json t:render="editing_allowed"/>;
-    const attachmentsAllowed        = <json t:render="file_attachments_allowed"/>;
-</script>
-
 <body>
   <div xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" t:render="container">
 

--- a/src/ims/element/incident/incidents/_incidents.py
+++ b/src/ims/element/incident/incidents/_incidents.py
@@ -19,12 +19,7 @@ Incidents page.
 """
 
 from attrs import mutable
-from klein import KleinRenderable
-from twisted.web.iweb import IRequest
-from twisted.web.template import Tag, renderer
 
-from ims.auth import Authorization
-from ims.ext.json_ext import jsonFalse, jsonTrue
 from ims.model import Event
 
 from ...page import Page
@@ -41,15 +36,3 @@ class IncidentsPage(Page):
 
     name: str = "Incidents"
     event: Event
-
-    @renderer
-    def editing_allowed(self, request: IRequest, tag: Tag) -> KleinRenderable:
-        """
-        JSON boolean, true if editing is allowed.
-        """
-        if (
-            request.authorizations  # type: ignore[attr-defined]
-            & Authorization.writeIncidents
-        ):
-            return jsonTrue
-        return jsonFalse

--- a/src/ims/element/incident/incidents/template.xhtml
+++ b/src/ims/element/incident/incidents/template.xhtml
@@ -2,10 +2,6 @@
 <html xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" t:render="root">
 <head t:render="head" imports="theme,dataTables" module="viewIncidents"/>
 
-<script>
-    const editingAllowed            = <json t:render="editing_allowed"/>;
-</script>
-
 <body>
   <div xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" t:render="container">
 

--- a/src/ims/element/incident/report/_report.py
+++ b/src/ims/element/incident/report/_report.py
@@ -42,7 +42,6 @@ class FieldReportPage(Page):
     name: str = "Field Report Details"
     hideH1: bool = True
     event: Event
-    number: int | None
 
     @renderer
     def editing_allowed(self, request: IRequest, tag: Tag) -> KleinRenderable:

--- a/src/ims/element/incident/report/template.xhtml
+++ b/src/ims/element/incident/report/template.xhtml
@@ -3,11 +3,6 @@
 
 <head t:render="head" imports="theme" module="viewFieldReport"/>
 
-<script>
-    const editingAllowed      = <json t:render="editing_allowed"/>;
-    const canWriteIncidents   = <json t:render="can_write_incidents"/>;
-</script>
-
 <body>
   <div xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" t:render="container">
 

--- a/src/ims/element/incident/reports/_reports.py
+++ b/src/ims/element/incident/reports/_reports.py
@@ -19,12 +19,7 @@ Field reports page element.
 """
 
 from attrs import mutable
-from klein import KleinRenderable
-from twisted.web.iweb import IRequest
-from twisted.web.template import Tag, renderer
 
-from ims.auth import Authorization
-from ims.ext.json_ext import jsonFalse, jsonTrue
 from ims.model import Event
 
 from ...page import Page
@@ -41,15 +36,3 @@ class FieldReportsPage(Page):
 
     name: str = "Field Reports"
     event: Event
-
-    @renderer
-    def editing_allowed(self, request: IRequest, tag: Tag) -> KleinRenderable:
-        """
-        JSON boolean, true if editing is allowed.
-        """
-        if (
-            request.authorizations  # type: ignore[attr-defined]
-            & Authorization.writeFieldReports
-        ):
-            return jsonTrue
-        return jsonFalse

--- a/src/ims/element/incident/reports/template.xhtml
+++ b/src/ims/element/incident/reports/template.xhtml
@@ -2,10 +2,6 @@
 <html xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" t:render="root">
 <head t:render="head" imports="theme,dataTables" module="viewFieldReports"/>
 
-<script>
-    const editingAllowed    = <json t:render="editing_allowed"/>;
-</script>
-
 <body>
   <div xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" t:render="container">
 

--- a/src/ims/element/login/template.xhtml
+++ b/src/ims/element/login/template.xhtml
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" t:render="root">
-<head t:render="head" imports="theme" module="basic"/>
+<head t:render="head" imports="theme" module="login"/>
 
 <body>
 <div t:render="container">
@@ -8,8 +8,8 @@
   <form method="POST" id="login_form" class="form-horizontal">
 
     <button t:render="if_authn_failed" type="button" class="btn btn-block btn-danger">Authentication Failed</button>
-    <button t:render="if_logged_in" type="button" class="btn btn-block btn-danger">You are already logged in as <span
-            t:render="logged_in_user"/></button>
+    <button type="button" class="btn btn-block btn-danger if-logged-in hidden">You are already logged in as <span
+            class="logged-in-user"/></button>
 
     <p>
       Please log in with your Ranger Secret Clubhouse credentials.

--- a/src/ims/element/page/nav/template.xhtml
+++ b/src/ims/element/page/nav/template.xhtml
@@ -42,7 +42,7 @@
     </button>
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <!-- Event menu -->
-      <ul class="navbar-nav" t:render="if_logged_in">
+      <ul class="navbar-nav if-logged-in hidden">
         <li class="nav-item dropdown">
           <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown"
              aria-expanded="false">
@@ -103,19 +103,19 @@
       </ul>
 
       <!-- Not logged in: offer to log in -->
-      <ul class="navbar-nav" t:render="if_not_logged_in">
+      <ul class="navbar-nav if-not-logged-in hidden">
         <li id="nav_login"><a t:render="url" url="login" class="nav-link">Log In</a></li>
       </ul>
 
       <!-- Logged in: show user menu -->
-      <ul class="navbar-nav" t:render="if_logged_in">
+      <ul class="navbar-nav if-logged-in hidden">
         <li class="nav-item dropdown">
           <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown"
              aria-expanded="false">
-            <span t:render="logged_in_user"/>
+            <span class="logged-in-user"/>
           </a>
           <ul class="dropdown-menu">
-            <li t:render="if_admin"><a t:render="url" url="admin" class="dropdown-item">Admin</a></li>
+            <li class="if-admin hidden"><a t:render="url" url="admin" class="dropdown-item">Admin</a></li>
             <li><a t:render="url" url="logout" class="dropdown-item">Log out</a></li>
           </ul>
         </li>

--- a/src/ims/element/root/template.xhtml
+++ b/src/ims/element/root/template.xhtml
@@ -1,21 +1,20 @@
 <!DOCTYPE html>
 <html xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1">
-<head t:render="head" imports="theme" module="basic"/>
+<head t:render="head" imports="theme" module="root"/>
 
 <body t:render="container">
 
-<p class="mt-3" t:render="if_logged_in">
+<p class="mt-3 if-logged-in hidden">
   Select an event from the pop-up above.
 </p>
-<p class="mt-3" t:render="if_logged_in">
+<p class="mt-3 if-logged-in hidden">
   <a href="https://github.com/burningmantech/ranger-ims-server/wiki/What's-New-in-IMS">See what's new in IMS for 2025.</a>
 </p>
-<p t:render="if_logged_in">
+<p class="if-logged-in hidden">
   On a shared machine? <strong>Please log out</strong> when you're done.
 </p>
 
-<p t:render="if_not_logged_in">
-  <div class="btn-group" role="group">
+  <div class="btn-group mb-3 if-not-logged-in hidden" role="group">
     <a t:render="url"
        url="login"
        id="login-button"
@@ -25,10 +24,8 @@
       Log In
     </a>
   </div>
-</p>
 
-<p t:render="if_logged_in">
-  <div class="btn-group" role="group">
+  <div class="btn-group mb-3 if-logged-in hidden" role="group">
     <a t:render="url"
        url="logout"
        role="button"
@@ -37,7 +34,6 @@
       Log Out
     </a>
   </div>
-</p>
 
 </body>
 

--- a/src/ims/element/static/admin_events.js
+++ b/src/ims/element/static/admin_events.js
@@ -17,7 +17,11 @@ import * as ims from "./ims.js";
 //
 initAdminEventsPage();
 async function initAdminEventsPage() {
-    ims.commonPageInit();
+    const initResult = await ims.commonPageInit();
+    if (!initResult.authInfo.authenticated) {
+        ims.redirectToLogin();
+        return;
+    }
     window.setValidity = setValidity;
     window.addEvent = addEvent;
     window.addAccess = addAccess;

--- a/src/ims/element/static/admin_root.js
+++ b/src/ims/element/static/admin_root.js
@@ -1,0 +1,25 @@
+// See the file COPYRIGHT for copyright information.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import * as ims from "./ims.js";
+//
+// Initialize UI
+//
+initAdminRootPage();
+async function initAdminRootPage() {
+    const initResult = await ims.commonPageInit();
+    if (!initResult.authInfo.authenticated) {
+        ims.redirectToLogin();
+        return;
+    }
+}

--- a/src/ims/element/static/admin_streets.js
+++ b/src/ims/element/static/admin_streets.js
@@ -18,18 +18,20 @@ let eventDatas = [];
 //
 initAdminStreetsPage();
 async function initAdminStreetsPage() {
-    ims.commonPageInit();
-    const { json, err } = await ims.fetchJsonNoThrow(url_events, null);
-    if (err != null || json == null) {
-        console.error(`Failed to fetch events: ${err}`);
-        window.alert(`Failed to fetch events: ${err}`);
+    const initResult = await ims.commonPageInit();
+    if (!initResult.authInfo.authenticated) {
+        ims.redirectToLogin();
         return;
     }
-    eventDatas = json;
+    if (initResult.eventDatas == null) {
+        console.error(`Failed to fetch events`);
+        return;
+    }
+    eventDatas = initResult.eventDatas;
     window.addStreet = addStreet;
     window.removeStreet = removeStreet;
-    const { err: err2 } = await loadStreets();
-    if (err2 == null) {
+    const { err } = await loadStreets();
+    if (err == null) {
         drawStreets();
     }
 }

--- a/src/ims/element/static/admin_types.js
+++ b/src/ims/element/static/admin_types.js
@@ -17,12 +17,17 @@ import * as ims from "./ims.js";
 //
 initAdminTypesPage();
 async function initAdminTypesPage() {
-    ims.commonPageInit();
+    const initResult = await ims.commonPageInit();
+    if (!initResult.authInfo.authenticated) {
+        ims.redirectToLogin();
+        return;
+    }
     window.createIncidentType = createIncidentType;
     window.deleteIncidentType = deleteIncidentType;
     window.showIncidentType = showIncidentType;
     window.hideIncidentType = hideIncidentType;
     await loadAndDrawIncidentTypes();
+    ims.enableEditing();
 }
 async function loadAndDrawIncidentTypes() {
     await loadAllIncidentTypes();

--- a/src/ims/element/static/field_report.js
+++ b/src/ims/element/static/field_report.js
@@ -18,7 +18,11 @@ let fieldReport = null;
 //
 initFieldReportPage();
 async function initFieldReportPage() {
-    ims.commonPageInit();
+    const initResult = await ims.commonPageInit();
+    if (!initResult.authInfo.authenticated) {
+        ims.redirectToLogin();
+        return;
+    }
     window.makeIncident = makeIncident;
     window.editSummary = editSummary;
     window.toggleShowHistory = ims.toggleShowHistory;
@@ -137,7 +141,7 @@ async function loadAndDisplayFieldReport() {
     ims.drawReportEntries(fieldReport.report_entries ?? []);
     ims.clearErrorMessage();
     document.getElementById("report_entry_add").addEventListener("input", ims.reportEntryEdited);
-    if (editingAllowed) {
+    if (ims.eventAccess?.writeFieldReports) {
         ims.enableEditing();
     }
 }
@@ -179,7 +183,7 @@ function drawIncident() {
     }
     // If there's no attached Incident, show a button for making
     // a new Incident
-    if (incident == null && canWriteIncidents) {
+    if (incident == null && ims.eventAccess?.writeIncidents) {
         document.getElementById("create_incident").classList.remove("hidden");
     }
     else {

--- a/src/ims/element/static/field_reports.js
+++ b/src/ims/element/static/field_reports.js
@@ -25,7 +25,11 @@ const frDefaultRows = 25;
 //
 initFieldReportsPage();
 async function initFieldReportsPage() {
-    ims.commonPageInit();
+    const initResult = await ims.commonPageInit();
+    if (!initResult.authInfo.authenticated) {
+        ims.redirectToLogin();
+        return;
+    }
     window.frShowDays = frShowDays;
     window.frShowRows = frShowRows;
     ims.disableEditing();
@@ -72,7 +76,7 @@ function initFieldReportsTable() {
     frInitSearchField();
     frInitSearch();
     ims.clearErrorMessage();
-    if (editingAllowed) {
+    if (ims.eventAccess?.writeFieldReports) {
         ims.enableEditing();
     }
     ims.requestEventSourceLock();

--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -20,7 +20,11 @@ let incidentTypes = [];
 //
 initIncidentPage();
 async function initIncidentPage() {
-    ims.commonPageInit();
+    const initResult = await ims.commonPageInit();
+    if (!initResult.authInfo.authenticated) {
+        ims.redirectToLogin();
+        return;
+    }
     window.editState = editState;
     window.editIncidentSummary = editIncidentSummary;
     window.editLocationName = editLocationName;
@@ -176,10 +180,10 @@ async function loadAndDisplayIncident() {
     }
     drawIncidentFields();
     ims.clearErrorMessage();
-    if (editingAllowed) {
+    if (ims.eventAccess?.writeIncidents) {
         ims.enableEditing();
     }
-    if (attachmentsAllowed) {
+    if (ims.eventAccess?.attachFiles) {
         document.getElementById("attach_file").classList.remove("hidden");
     }
 }

--- a/src/ims/element/static/login.js
+++ b/src/ims/element/static/login.js
@@ -15,7 +15,7 @@ import * as ims from "./ims.js";
 //
 // Initialize UI
 //
-initBasicPage();
-function initBasicPage() {
-    ims.commonPageInit();
+initLoginPage();
+async function initLoginPage() {
+    await ims.commonPageInit();
 }

--- a/src/ims/element/static/root.js
+++ b/src/ims/element/static/root.js
@@ -1,0 +1,21 @@
+// See the file COPYRIGHT for copyright information.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import * as ims from "./ims.js";
+//
+// Initialize UI
+//
+initRootPage();
+async function initRootPage() {
+    await ims.commonPageInit();
+}

--- a/src/ims/element/typescript/admin_events.ts
+++ b/src/ims/element/typescript/admin_events.ts
@@ -33,7 +33,11 @@ declare global {
 initAdminEventsPage();
 
 async function initAdminEventsPage(): Promise<void> {
-    ims.commonPageInit();
+    const initResult = await ims.commonPageInit();
+    if (!initResult.authInfo.authenticated) {
+        ims.redirectToLogin();
+        return;
+    }
 
     window.setValidity = setValidity;
     window.addEvent = addEvent;

--- a/src/ims/element/typescript/admin_root.ts
+++ b/src/ims/element/typescript/admin_root.ts
@@ -1,0 +1,29 @@
+// See the file COPYRIGHT for copyright information.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as ims from "./ims.ts";
+
+//
+// Initialize UI
+//
+
+initAdminRootPage();
+
+async function initAdminRootPage(): Promise<void> {
+    const initResult = await ims.commonPageInit();
+    if (!initResult.authInfo.authenticated) {
+        ims.redirectToLogin();
+        return;
+    }
+}

--- a/src/ims/element/typescript/admin_streets.ts
+++ b/src/ims/element/typescript/admin_streets.ts
@@ -14,7 +14,6 @@
 
 import * as ims from "./ims.ts";
 
-declare let url_events: string;
 declare let url_streets: string;
 
 declare global {
@@ -32,22 +31,23 @@ let eventDatas: ims.EventData[] = [];
 
 initAdminStreetsPage();
 
-async function initAdminStreetsPage() {
-    ims.commonPageInit();
-
-    const {json, err} = await ims.fetchJsonNoThrow<ims.EventData[]>(url_events, null);
-    if (err != null || json == null) {
-        console.error(`Failed to fetch events: ${err}`);
-        window.alert(`Failed to fetch events: ${err}`);
+async function initAdminStreetsPage(): Promise<void> {
+    const initResult = await ims.commonPageInit();
+    if (!initResult.authInfo.authenticated) {
+        ims.redirectToLogin();
         return;
     }
-    eventDatas = json;
+    if (initResult.eventDatas == null) {
+        console.error(`Failed to fetch events`);
+        return;
+    }
+    eventDatas = initResult.eventDatas;
 
     window.addStreet = addStreet;
     window.removeStreet = removeStreet;
 
-    const {err: err2} = await loadStreets();
-    if (err2 == null) {
+    const {err} = await loadStreets();
+    if (err == null) {
         drawStreets();
     }
 }

--- a/src/ims/element/typescript/admin_types.ts
+++ b/src/ims/element/typescript/admin_types.ts
@@ -32,7 +32,11 @@ declare global {
 initAdminTypesPage();
 
 async function initAdminTypesPage(): Promise<void> {
-    ims.commonPageInit();
+    const initResult = await ims.commonPageInit();
+    if (!initResult.authInfo.authenticated) {
+        ims.redirectToLogin();
+        return;
+    }
 
     window.createIncidentType = createIncidentType;
     window.deleteIncidentType = deleteIncidentType;
@@ -40,6 +44,8 @@ async function initAdminTypesPage(): Promise<void> {
     window.hideIncidentType = hideIncidentType;
 
     await loadAndDrawIncidentTypes();
+
+    ims.enableEditing();
 }
 
 

--- a/src/ims/element/typescript/field_report.ts
+++ b/src/ims/element/typescript/field_report.ts
@@ -14,9 +14,6 @@
 
 import * as ims from "./ims.ts";
 
-declare let editingAllowed: boolean|null|undefined;
-declare let canWriteIncidents: boolean|null|undefined;
-
 declare let url_incidents: string;
 declare let url_viewFieldReports: string;
 declare let url_fieldReports: string;
@@ -41,7 +38,11 @@ let fieldReport: ims.FieldReport|null = null;
 initFieldReportPage();
 
 async function initFieldReportPage(): Promise<void> {
-    ims.commonPageInit();
+    const initResult = await ims.commonPageInit();
+    if (!initResult.authInfo.authenticated) {
+        ims.redirectToLogin();
+        return;
+    }
 
     window.makeIncident = makeIncident;
     window.editSummary = editSummary;
@@ -176,7 +177,7 @@ async function loadAndDisplayFieldReport(): Promise<void> {
 
     document.getElementById("report_entry_add")!.addEventListener("input", ims.reportEntryEdited);
 
-    if (editingAllowed) {
+    if (ims.eventAccess?.writeFieldReports) {
         ims.enableEditing();
     }
 }
@@ -227,7 +228,7 @@ function drawIncident(): void {
     }
     // If there's no attached Incident, show a button for making
     // a new Incident
-    if (incident == null && canWriteIncidents) {
+    if (incident == null && ims.eventAccess?.writeIncidents) {
         document.getElementById("create_incident")!.classList.remove("hidden");
     } else {
         document.getElementById("create_incident")!.classList.add("hidden");

--- a/src/ims/element/typescript/field_reports.ts
+++ b/src/ims/element/typescript/field_reports.ts
@@ -14,8 +14,6 @@
 
 import * as ims from "./ims.ts";
 
-declare let editingAllowed: boolean|null|undefined;
-
 declare let url_viewFieldReports: string;
 declare let url_fieldReports: string;
 
@@ -45,7 +43,11 @@ const frDefaultRows = 25;
 initFieldReportsPage();
 
 async function initFieldReportsPage(): Promise<void> {
-    ims.commonPageInit();
+    const initResult = await ims.commonPageInit();
+    if (!initResult.authInfo.authenticated) {
+        ims.redirectToLogin();
+        return;
+    }
 
     window.frShowDays = frShowDays;
     window.frShowRows = frShowRows;
@@ -100,7 +102,7 @@ function initFieldReportsTable() {
     frInitSearch();
     ims.clearErrorMessage();
 
-    if (editingAllowed) {
+    if (ims.eventAccess?.writeFieldReports) {
         ims.enableEditing();
     }
 

--- a/src/ims/element/typescript/incident.ts
+++ b/src/ims/element/typescript/incident.ts
@@ -14,14 +14,10 @@
 
 import * as ims from "./ims.ts";
 
-declare let editingAllowed: boolean|null|undefined;
-declare let attachmentsAllowed: boolean|null|undefined;
-
 declare let url_incidents: string;
 declare let url_viewIncidents: string;
 declare let url_viewFieldReports: string;
 declare let url_personnel: string;
-declare let url_incidentTypes: string;
 declare let url_fieldReports: string;
 declare let url_fieldReport: string;
 declare let url_incidentAttachments: string;
@@ -62,7 +58,11 @@ let incidentTypes: string[] = [];
 initIncidentPage();
 
 async function initIncidentPage(): Promise<void> {
-    ims.commonPageInit();
+    const initResult = await ims.commonPageInit();
+    if (!initResult.authInfo.authenticated) {
+        ims.redirectToLogin();
+        return;
+    }
 
     window.editState = editState;
     window.editIncidentSummary = editIncidentSummary;
@@ -234,11 +234,11 @@ async function loadAndDisplayIncident(): Promise<void> {
     drawIncidentFields();
     ims.clearErrorMessage();
 
-    if (editingAllowed) {
+    if (ims.eventAccess?.writeIncidents) {
         ims.enableEditing();
     }
 
-    if (attachmentsAllowed) {
+    if (ims.eventAccess?.attachFiles) {
         (document.getElementById("attach_file") as HTMLInputElement).classList.remove("hidden");
     }
 }

--- a/src/ims/element/typescript/login.ts
+++ b/src/ims/element/typescript/login.ts
@@ -1,0 +1,25 @@
+// See the file COPYRIGHT for copyright information.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as ims from "./ims.ts";
+
+//
+// Initialize UI
+//
+
+initLoginPage();
+
+async function initLoginPage(): Promise<void> {
+    await ims.commonPageInit();
+}

--- a/src/ims/element/typescript/root.ts
+++ b/src/ims/element/typescript/root.ts
@@ -18,8 +18,8 @@ import * as ims from "./ims.ts";
 // Initialize UI
 //
 
-initBasicPage();
+initRootPage();
 
-function initBasicPage(): void {
-    ims.commonPageInit();
+async function initRootPage(): Promise<void> {
+    await ims.commonPageInit();
 }


### PR DESCRIPTION
wow, this became a huge PR...

this fully makes us able to use an Authorization header rather than TWISTED_SESSION cookies, because it moves all authenticated actions into API requests from the client. This meant removing any server-side templating involving authenticated information. Now all of the page endpoints can be retrieved by anyone (whether signed in or not), and the JavaScript is responsible for putting all the useful information into those pages on the client side.

https://github.com/burningmantech/ranger-ims-server/issues/1671