### PR TITLE
make the incidents page load faster

### DIFF
--- a/src/ims/application/_api.py
+++ b/src/ims/application/_api.py
@@ -377,6 +377,7 @@ class APIApplication:
         return noContentResponse(request)
 
     @router.route(_unprefix(URLs.events), methods=("HEAD", "GET"))
+    @static
     async def eventsResource(self, request: IRequest) -> KleinSynchronousRenderable:
         """
         Events endpoint.
@@ -1396,6 +1397,7 @@ class APIApplication:
         return noContentResponse(request)
 
     @router.route(_unprefix(URLs.streets), methods=("HEAD", "GET"))
+    @static
     async def readStreetsResource(
         self, request: IRequest
     ) -> KleinSynchronousRenderable:

--- a/src/ims/application/_klein.py
+++ b/src/ims/application/_klein.py
@@ -431,6 +431,7 @@ class Router(Klein):
             # This is because exposing what resources do or do not exist can
             # expose information that was not meant to be exposed.
             app.config.authProvider.authenticateRequest(request)
+            request.setHeader(HeaderName.cacheControl.value, "no-cache")
             return notFoundResponse(request)
 
         @self.handle_errors(MethodNotAllowed)
@@ -459,6 +460,7 @@ class Router(Klein):
             """
             Not authorized.
             """
+            request.setHeader(HeaderName.cacheControl.value, "no-cache")
             return friendlyNotAuthorizedResponse(request)
 
         @self.handle_errors(InvalidCredentialsError)
@@ -471,6 +473,7 @@ class Router(Klein):
             """
             Invalid credentials.
             """
+            request.setHeader(HeaderName.cacheControl.value, "no-cache")
             return forbiddenResponse(request)
 
         @self.handle_errors(NotAuthenticatedError)
@@ -485,6 +488,7 @@ class Router(Klein):
             """
             requestedWith = request.getHeader("X-Requested-With")
             if requestedWith == "XMLHttpRequest":
+                request.setHeader(HeaderName.cacheControl.value, "no-cache")
                 return forbiddenResponse(request)
 
             element = redirect(request, URLs.login, origin="o")

--- a/src/ims/application/_main.py
+++ b/src/ims/application/_main.py
@@ -141,6 +141,7 @@ class MainApplication:
     #
 
     @router.route(URLs.urlsJS, methods=("HEAD", "GET"))
+    @static
     def urlsEndpoint(self, request: IRequest) -> KleinRenderable:
         """
         JavaScript variables for service URLs.

--- a/src/ims/element/static/admin_events.js
+++ b/src/ims/element/static/admin_events.js
@@ -38,6 +38,11 @@ var Validity;
 const allAccessModes = ["readers", "writers", "reporters"];
 let accessControlList = null;
 async function loadAccessControlList() {
+    // we don't actually need the response from this API, but we want to
+    // invalidate the local HTTP cache in the admin's browser
+    ims.fetchJsonNoThrow(url_events, {
+        headers: { "Cache-Control": "no-cache" },
+    });
     const { json, err } = await ims.fetchJsonNoThrow(url_acl, null);
     if (err != null) {
         const message = `Failed to load access control list: ${err}`;

--- a/src/ims/element/static/ims.js
+++ b/src/ims/element/static/ims.js
@@ -114,6 +114,10 @@ export async function fetchJsonNoThrow(url, init) {
     }
     init.headers = new Headers(init.headers);
     init.headers.set("Accept", "application/json");
+    // Pretend we're using XMLHttpRequest (rather than fetch API) so that the server
+    // follows this code path:
+    // https://github.com/burningmantech/ranger-ims-server/blob/0ae6fed861c7ba9d960d7e7ef3ba3258352a79c6/src/ims/application/_klein.py#L486
+    init.headers.set("X-Requested-With", "XMLHttpRequest");
     const tok = getAccessToken();
     if (tok) {
         init.headers.set("Authorization", "Bearer " + tok);

--- a/src/ims/element/typescript/admin_events.ts
+++ b/src/ims/element/typescript/admin_events.ts
@@ -69,6 +69,11 @@ type EventsAccess = Record<string, EventAccess|null>;
 let accessControlList: EventsAccess|null = null;
 
 async function loadAccessControlList() : Promise<{err: string|null}> {
+    // we don't actually need the response from this API, but we want to
+    // invalidate the local HTTP cache in the admin's browser
+    ims.fetchJsonNoThrow<ims.EventData[]>(url_events, {
+        headers: {"Cache-Control": "no-cache"},
+    });
     const {json, err} = await ims.fetchJsonNoThrow<EventsAccess>(url_acl, null);
     if (err != null) {
         const message = `Failed to load access control list: ${err}`;

--- a/src/ims/element/typescript/ims.ts
+++ b/src/ims/element/typescript/ims.ts
@@ -132,6 +132,10 @@ export async function fetchJsonNoThrow<T>(url: string, init: RequestInit|null):
     }
     init.headers = new Headers(init.headers);
     init.headers.set("Accept", "application/json");
+    // Pretend we're using XMLHttpRequest (rather than fetch API) so that the server
+    // follows this code path:
+    // https://github.com/burningmantech/ranger-ims-server/blob/0ae6fed861c7ba9d960d7e7ef3ba3258352a79c6/src/ims/application/_klein.py#L486
+    init.headers.set("X-Requested-With", "XMLHttpRequest");
     const tok = getAccessToken();
     if (tok) {
         init.headers.set("Authorization", "Bearer " + tok);


### PR DESCRIPTION
we're able to call to multiple endpoints concurrently to speed up the page load. Also we can make a few more endpoints static to speed them up too.

with this increased use of static, we also don't want clients caching error responses (something I saw locally). Thus I'm doing a bunch of no-cacheing on errors