### PR TITLE
reduce deadlock risk on adding Rangers and Incident Types to Incidents

### DIFF
--- a/src/ims/element/root/template.xhtml
+++ b/src/ims/element/root/template.xhtml
@@ -14,22 +14,22 @@
   On a shared machine? <strong>Please log out</strong> when you're done.
 </p>
 
-  <div class="btn-group mb-3 if-not-logged-in hidden" role="group">
+  <div class="btn-group mb-3" role="group">
     <a t:render="url"
        url="login"
        id="login-button"
        role="button"
-       class="btn btn-md btn-default btn-primary"
+       class="btn btn-md btn-default btn-primary if-not-logged-in hidden"
     >
       Log In
     </a>
   </div>
 
-  <div class="btn-group mb-3 if-logged-in hidden" role="group">
+  <div class="btn-group mb-3" role="group">
     <a t:render="url"
        url="logout"
        role="button"
-       class="btn btn-md btn-default btn-danger"
+       class="btn btn-md btn-default btn-danger if-logged-in hidden"
     >
       Log Out
     </a>

--- a/src/ims/element/static/admin_events.js
+++ b/src/ims/element/static/admin_events.js
@@ -127,6 +127,9 @@ async function addAccess(sender) {
     const event = container.getElementsByClassName("event_name")[0].textContent;
     const mode = container.getElementsByClassName("access_mode")[0].textContent;
     const newExpression = sender.value.trim();
+    if (newExpression === "") {
+        return;
+    }
     if (newExpression === "**") {
         const confirmed = confirm("Double-wildcard '**' ACLs are no longer supported, so this ACL will have " +
             "no effect.\n\n" +
@@ -149,7 +152,9 @@ async function addAccess(sender) {
             return;
         }
     }
-    const acl = accessControlList[event][mode].slice();
+    let acl = accessControlList[event][mode].slice();
+    // remove other acls for this mode for the same expression
+    acl = acl.filter((v) => { return v.expression !== newExpression; });
     const newVal = {
         "expression": newExpression,
         "validity": Validity.always,
@@ -201,7 +206,9 @@ async function setValidity(sender) {
     const event = container.getElementsByClassName("event_name")[0].textContent;
     const mode = container.getElementsByClassName("access_mode")[0].textContent;
     const expression = sender.parentElement.getAttribute("value").trim();
-    const acl = accessControlList[event][mode].slice();
+    let acl = accessControlList[event][mode].slice();
+    // remove other acls for this mode for the same expression
+    acl = acl.filter((v) => { return v.expression !== expression; });
     const newVal = {
         "expression": expression,
         "validity": sender.value === "onsite" ? Validity.onsite : Validity.always,

--- a/src/ims/element/static/incident.js
+++ b/src/ims/element/static/incident.js
@@ -742,8 +742,8 @@ function normalize(str) {
     return str.toLowerCase().trim();
 }
 async function addRanger() {
-    const select = document.getElementById("ranger_add");
-    let handle = select.value;
+    const addRanger = document.getElementById("ranger_add");
+    let handle = addRanger.value;
     // make a copy of the handles
     const handles = (incident.ranger_handles ?? []).slice();
     // fuzzy-match on handle, to allow case insensitivity and
@@ -759,27 +759,30 @@ async function addRanger() {
     }
     if (!(handle in (personnel ?? []))) {
         // Not a valid handle
-        select.value = "";
+        addRanger.value = "";
         return;
     }
     if (handles.indexOf(handle) !== -1) {
         // Already in the list, so… move along.
-        select.value = "";
+        addRanger.value = "";
         return;
     }
     handles.push(handle);
+    addRanger.disabled = true;
     const { err } = await sendEdits({ "ranger_handles": handles });
     if (err !== null) {
-        ims.controlHasError(select);
-        select.value = "";
+        ims.controlHasError(addRanger);
+        addRanger.value = "";
+        addRanger.disabled = false;
         return;
     }
-    select.value = "";
-    ims.controlHasSuccess(select, 1000);
+    addRanger.value = "";
+    addRanger.disabled = false;
+    ims.controlHasSuccess(addRanger, 1000);
 }
 async function addIncidentType() {
-    const select = document.getElementById("incident_type_add");
-    let incidentType = select.value;
+    const addType = document.getElementById("incident_type_add");
+    let incidentType = addType.value;
     // make a copy of the incident types
     const currentIncidentTypes = (incident.incident_types ?? []).slice();
     // fuzzy-match on incidentType, to allow case insensitivity and
@@ -795,23 +798,26 @@ async function addIncidentType() {
     }
     if (incidentTypes.indexOf(incidentType) === -1) {
         // Not a valid incident type
-        select.value = "";
+        addType.value = "";
         return;
     }
     if (currentIncidentTypes.indexOf(incidentType) !== -1) {
         // Already in the list, so… move along.
-        select.value = "";
+        addType.value = "";
         return;
     }
     currentIncidentTypes.push(incidentType);
+    addType.disabled = true;
     const { err } = await sendEdits({ "incident_types": currentIncidentTypes });
     if (err != null) {
-        ims.controlHasError(select);
-        select.value = "";
+        ims.controlHasError(addType);
+        addType.value = "";
+        addType.disabled = false;
         return;
     }
-    select.value = "";
-    ims.controlHasSuccess(select, 1000);
+    addType.value = "";
+    addType.disabled = false;
+    ims.controlHasSuccess(addType, 1000);
 }
 async function detachFieldReport(sender) {
     const parent = sender.parentElement;

--- a/src/ims/element/typescript/admin_events.ts
+++ b/src/ims/element/typescript/admin_events.ts
@@ -180,6 +180,10 @@ async function addAccess(sender: HTMLInputElement): Promise<void> {
     const mode = container.getElementsByClassName("access_mode")[0]!.textContent as AccessMode;
     const newExpression = sender.value.trim();
 
+    if (newExpression === "") {
+        return;
+    }
+
     if (newExpression === "**") {
         const confirmed = confirm(
             "Double-wildcard '**' ACLs are no longer supported, so this ACL will have " +
@@ -208,7 +212,10 @@ async function addAccess(sender: HTMLInputElement): Promise<void> {
         }
     }
 
-    const acl: Access[] = accessControlList![event]![mode]!.slice();
+    let acl: Access[] = accessControlList![event]![mode]!.slice();
+
+    // remove other acls for this mode for the same expression
+    acl = acl.filter((v: Access): boolean => {return v.expression !== newExpression});
 
     const newVal: Access = {
         "expression": newExpression,
@@ -273,7 +280,10 @@ async function setValidity(sender: HTMLSelectElement): Promise<void> {
     const mode = container.getElementsByClassName("access_mode")[0]!.textContent! as AccessMode;
     const expression = sender.parentElement!.getAttribute("value")!.trim();
 
-    const acl: Access[] = accessControlList![event]![mode]!.slice();
+    let acl: Access[] = accessControlList![event]![mode]!.slice();
+
+    // remove other acls for this mode for the same expression
+    acl = acl.filter((v: Access): boolean => {return v.expression !== expression});
 
     const newVal: Access = {
         "expression": expression,

--- a/src/ims/element/typescript/incident.ts
+++ b/src/ims/element/typescript/incident.ts
@@ -962,8 +962,8 @@ function normalize(str: string): string {
 }
 
 async function addRanger(): Promise<void> {
-    const select = document.getElementById("ranger_add") as HTMLSelectElement;
-    let handle: string = select.value;
+    const addRanger = document.getElementById("ranger_add") as HTMLInputElement;
+    let handle: string = addRanger.value;
 
     // make a copy of the handles
     const handles = (incident!.ranger_handles??[]).slice();
@@ -981,32 +981,35 @@ async function addRanger(): Promise<void> {
     }
     if (!(handle in (personnel??[]))) {
         // Not a valid handle
-        select.value = "";
+        addRanger.value = "";
         return;
     }
 
     if (handles.indexOf(handle) !== -1) {
         // Already in the list, so… move along.
-        select.value = "";
+        addRanger.value = "";
         return;
     }
 
     handles.push(handle);
 
+    addRanger.disabled = true;
     const {err} = await sendEdits({"ranger_handles": handles});
     if (err !== null) {
-        ims.controlHasError(select);
-        select.value = "";
+        ims.controlHasError(addRanger);
+        addRanger.value = "";
+        addRanger.disabled = false;
         return;
     }
-    select.value = "";
-    ims.controlHasSuccess(select, 1000);
+    addRanger.value = "";
+    addRanger.disabled = false;
+    ims.controlHasSuccess(addRanger, 1000);
 }
 
 
 async function addIncidentType(): Promise<void> {
-    const select = document.getElementById("incident_type_add") as HTMLSelectElement;
-    let incidentType = select.value;
+    const addType = document.getElementById("incident_type_add") as HTMLInputElement;
+    let incidentType = addType.value;
 
     // make a copy of the incident types
     const currentIncidentTypes = (incident!.incident_types??[]).slice();
@@ -1024,26 +1027,29 @@ async function addIncidentType(): Promise<void> {
     }
     if (incidentTypes.indexOf(incidentType) === -1) {
         // Not a valid incident type
-        select.value = "";
+        addType.value = "";
         return;
     }
 
     if (currentIncidentTypes.indexOf(incidentType) !== -1) {
         // Already in the list, so… move along.
-        select.value = "";
+        addType.value = "";
         return;
     }
 
     currentIncidentTypes.push(incidentType);
 
+    addType.disabled = true;
     const {err} = await sendEdits({"incident_types": currentIncidentTypes});
     if (err != null) {
-        ims.controlHasError(select);
-        select.value = "";
+        ims.controlHasError(addType);
+        addType.value = "";
+        addType.disabled = false;
         return;
     }
-    select.value = "";
-    ims.controlHasSuccess(select, 1000);
+    addType.value = "";
+    addType.disabled = false;
+    ims.controlHasSuccess(addType, 1000);
 }
 
 

--- a/src/ims/store/mysql/_queries.py
+++ b/src/ims/store/mysql/_queries.py
@@ -285,6 +285,16 @@ queries = Queries(
         values (({query_eventID}), %(incidentNumber)s, %(rangerHandle)s)
         """,
     ),
+    detachRangerHandleFromIncident=Query(
+        "remove Ranger from incident",
+        f"""
+        delete from INCIDENT__RANGER
+        where
+            EVENT = ({query_eventID})
+            and INCIDENT_NUMBER = %(incidentNumber)s
+            and RANGER_HANDLE = %(rangerHandle)s
+        """,
+    ),
     attachIncidentTypeToIncident=Query(
         "add incident type to incident",
         f"""
@@ -296,6 +306,18 @@ queries = Queries(
             %(incidentNumber)s,
             (select ID from INCIDENT_TYPE where NAME = %(incidentType)s)
         )
+        """,
+    ),
+    detachIncidentTypeFromIncident=Query(
+        "remove incident type from incident",
+        f"""
+        delete from INCIDENT__INCIDENT_TYPE
+        where
+            EVENT = ({query_eventID})
+            and INCIDENT_NUMBER = %(incidentNumber)s
+            and INCIDENT_TYPE = (
+                select ID from INCIDENT_TYPE where NAME = %(incidentType)s
+            )
         """,
     ),
     createReportEntry=Query(

--- a/src/ims/store/sqlite/_queries.py
+++ b/src/ims/store/sqlite/_queries.py
@@ -279,6 +279,16 @@ queries = Queries(
         values (({query_eventID}), :incidentNumber, :rangerHandle)
         """,
     ),
+    detachRangerHandleFromIncident=Query(
+        "remove Ranger from incident",
+        f"""
+        delete from INCIDENT__RANGER
+        where
+            EVENT = ({query_eventID})
+            and INCIDENT_NUMBER = :incidentNumber
+            and RANGER_HANDLE = :rangerHandle
+        """,
+    ),
     attachIncidentTypeToIncident=Query(
         "add incident type to incident",
         f"""
@@ -290,6 +300,18 @@ queries = Queries(
             :incidentNumber,
             (select ID from INCIDENT_TYPE where NAME = :incidentType)
         )
+        """,
+    ),
+    detachIncidentTypeFromIncident=Query(
+        "remove incident type from incident",
+        f"""
+        delete from INCIDENT__INCIDENT_TYPE
+        where
+            EVENT = ({query_eventID})
+            and INCIDENT_NUMBER = :incidentNumber
+            and INCIDENT_TYPE = (
+                select ID from INCIDENT_TYPE where NAME = :incidentType
+            )
         """,
     ),
     createReportEntry=Query(


### PR DESCRIPTION
the previous approach always transactionally deleted all Rangers or Incident Types on an incident before adding new ones/adding all the old ones back. That led to deadlocks if multiple users were trying to add Rangers/Incident Types at the same time, even if they were acting on different Incidents. That's because those transactions had to acquire table locks to do their deletions.

This simplifies the approach, and instead just adds/removes the particular rows that need to be added or removed. This doesn't totally remove the possibility of deadlock, but I haven't seen any more instances of it in my automated testing with this commit in place.