### PR TITLE
on page init, don't wait for events call before loading page body

### DIFF
--- a/playwright/tests/ims.spec.ts
+++ b/playwright/tests/ims.spec.ts
@@ -22,7 +22,6 @@ async function login(page: Page): Promise<void> {
 
 async function adminPage(page: Page): Promise<void> {
   await maybeOpenNav(page);
-  await page.getByRole("button", { name: "Event" }).click();
   await page.getByRole("button", { name: username }).click();
   await page.getByRole("link", { name: "Admin" }).click();
 }
@@ -132,6 +131,10 @@ test("admin_events", async ({ browser }) => {
     await expect(writers.getByText("person:SomeGuy")).toBeVisible();
     await expect(writers.locator("select")).toHaveValue("onsite");
   }).toPass();
+
+  await page2.close();
+  await page.close();
+  await ctx.close();
 })
 
 test("incidents", async ({ page, browser }) => {
@@ -276,5 +279,6 @@ test("incidents", async ({ page, browser }) => {
 
     await incidentPage.close();
     await incidentsPage.close();
+    await ctx.close();
   }
 })

--- a/src/ims/element/static/admin_streets.js
+++ b/src/ims/element/static/admin_streets.js
@@ -23,11 +23,12 @@ async function initAdminStreetsPage() {
         ims.redirectToLogin();
         return;
     }
-    if (initResult.eventDatas == null) {
+    const eds = await initResult.eventDatas;
+    if (eds == null) {
         console.error(`Failed to fetch events`);
         return;
     }
-    eventDatas = initResult.eventDatas;
+    eventDatas = eds;
     window.addStreet = addStreet;
     window.removeStreet = removeStreet;
     const { err } = await loadStreets();

--- a/src/ims/element/static/field_reports.js
+++ b/src/ims/element/static/field_reports.js
@@ -108,10 +108,8 @@ function initFieldReportsTable() {
 // Initialize DataTables
 //
 function frInitDataTables() {
-    // @ts-expect-error JQuery
-    $.fn.dataTable.ext.errMode = "none";
-    // @ts-expect-error JQuery
-    fieldReportsTable = $("#field_reports_table").DataTable({
+    DataTable.ext.errMode = "none";
+    fieldReportsTable = new DataTable("#field_reports_table", {
         "deferRender": true,
         "paging": true,
         "lengthChange": false,

--- a/src/ims/element/static/incidents.js
+++ b/src/ims/element/static/incidents.js
@@ -179,10 +179,8 @@ function initIncidentsTable() {
 // Initialize DataTables
 //
 function initDataTables() {
-    // @ts-expect-error JQuery
-    $.fn.dataTable.ext.errMode = "none";
-    // @ts-expect-error JQuery
-    incidentsTable = $("#queue_table").DataTable({
+    DataTable.ext.errMode = "none";
+    incidentsTable = new DataTable("#queue_table", {
         "deferRender": true,
         "paging": true,
         "lengthChange": false,

--- a/src/ims/element/typescript/admin_streets.ts
+++ b/src/ims/element/typescript/admin_streets.ts
@@ -37,11 +37,12 @@ async function initAdminStreetsPage(): Promise<void> {
         ims.redirectToLogin();
         return;
     }
-    if (initResult.eventDatas == null) {
+    const eds: ims.EventData[]|null = await initResult.eventDatas;
+    if (eds == null) {
         console.error(`Failed to fetch events`);
         return;
     }
-    eventDatas = initResult.eventDatas;
+    eventDatas = eds;
 
     window.addStreet = addStreet;
     window.removeStreet = removeStreet;

--- a/src/ims/element/typescript/field_reports.ts
+++ b/src/ims/element/typescript/field_reports.ts
@@ -134,15 +134,15 @@ function initFieldReportsTable() {
     };
 }
 
+declare let DataTable: any;
+
 //
 // Initialize DataTables
 //
 
 function frInitDataTables() {
-    // @ts-expect-error JQuery
-    $.fn.dataTable.ext.errMode = "none";
-    // @ts-expect-error JQuery
-    fieldReportsTable = $("#field_reports_table").DataTable({
+    DataTable.ext.errMode = "none";
+    fieldReportsTable = new DataTable("#field_reports_table", {
         "deferRender": true,
         "paging": true,
         "lengthChange": false,

--- a/src/ims/element/typescript/incidents.ts
+++ b/src/ims/element/typescript/incidents.ts
@@ -230,16 +230,15 @@ function initIncidentsTable() {
     };
 }
 
+declare let DataTable: any;
 
 //
 // Initialize DataTables
 //
 
 function initDataTables(): void {
-    // @ts-expect-error JQuery
-    $.fn.dataTable.ext.errMode = "none";
-    // @ts-expect-error JQuery
-    incidentsTable = $("#queue_table").DataTable({
+    DataTable.ext.errMode = "none";
+    incidentsTable = new DataTable("#queue_table", {
         "deferRender": true,
         "paging": true,
         "lengthChange": false,


### PR DESCRIPTION
we need to call for all events in order to draw the events dropdown in the navbar. That call shouldn't block drawing of page body. We can instead do that call/drawing asynchronously.