### PR TITLE
exclude test source files from coverage metrics

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,8 @@
 branch = True
 parallel = True
 source = ims
+omit =
+   */test_*.py
 
 [paths]
 source=


### PR DESCRIPTION
It's misleading to include test source files themselves as part of coverage metrics, because they will always hit 100% and they aren't part of the deployed code itself.

I recently started wondering how IMS server could've had >70% coverage when there are some pretty large holes (e.g. _api.py). This is probably the culprit.