### PR TITLE
exclude test directories from coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,7 @@ branch = True
 parallel = True
 source = ims
 omit =
+   */test/*
    */test_*.py
 
 [paths]


### PR DESCRIPTION
this is a continuation of
https://github.com/burningmantech/ranger-ims-server/pull/1698

to better compare coverage in this project vs ranger-ims-go, test-only code shouldn't be counted toward coverage